### PR TITLE
Add grant-access and revoke-access Discord slash commands

### DIFF
--- a/src/Apollo.Core/API/IApolloServiceClient.cs
+++ b/src/Apollo.Core/API/IApolloServiceClient.cs
@@ -12,5 +12,7 @@ public interface IApolloServiceClient
 {
   Task<Result<ToDo>> CreateToDoAsync(CreateToDoRequest request, CancellationToken cancellationToken = default);
   Task<Result<IEnumerable<ToDoSummary>>> GetToDosAsync(PlatformId platformId, bool includeCompleted = false, CancellationToken cancellationToken = default);
+  Task<Result<string>> GrantAccessAsync(PlatformId adminPlatformId, PlatformId targetPlatformId, CancellationToken cancellationToken = default);
+  Task<Result<string>> RevokeAccessAsync(PlatformId adminPlatformId, PlatformId targetPlatformId, CancellationToken cancellationToken = default);
   Task<Result<string>> SendMessageAsync(NewMessageRequest request, CancellationToken cancellationToken = default);
 }

--- a/src/Apollo.Core/People/IPersonStore.cs
+++ b/src/Apollo.Core/People/IPersonStore.cs
@@ -14,6 +14,7 @@ public interface IPersonStore
   Task<Result<Person>> GetAsync(PersonId id, CancellationToken cancellationToken = default);
   Task<Result<Person>> GetByPlatformIdAsync(PlatformId platformId, CancellationToken cancellationToken = default);
   Task<Result> GrantAccessAsync(PersonId id, CancellationToken cancellationToken = default);
+  Task<Result> RevokeAccessAsync(PersonId id, CancellationToken cancellationToken = default);
   Task<Result> RemoveNotificationChannelAsync(Person person, NotificationChannel channel, CancellationToken cancellationToken = default);
   Task<Result> SetTimeZoneAsync(PersonId id, PersonTimeZoneId timeZoneId, CancellationToken cancellationToken = default);
   Task<Result> ToggleNotificationChannelAsync(Person person, NotificationChannel channel, CancellationToken cancellationToken = default);

--- a/src/Apollo.Discord/Modules/AdminCommandModule.cs
+++ b/src/Apollo.Discord/Modules/AdminCommandModule.cs
@@ -1,0 +1,73 @@
+using Apollo.Core.API;
+using Apollo.Domain.People.ValueObjects;
+
+using NetCord;
+using NetCord.Rest;
+using NetCord.Services.ApplicationCommands;
+
+using ApolloPlatform = Apollo.Domain.Common.Enums.Platform;
+
+namespace Apollo.Discord.Modules;
+
+public class AdminCommandModule(IApolloServiceClient apolloServiceClient) : ApplicationCommandModule<ApplicationCommandContext>
+{
+  [SlashCommand("grant-access", "Grant a user access to Apollo (Admin only)")]
+  public async Task GrantAccessAsync(
+    [SlashCommandParameter(Name = "user", Description = "The Discord user to grant access to")] User targetUser
+  )
+  {
+    _ = await RespondAsync(InteractionCallback.DeferredMessage(MessageFlags.Ephemeral));
+
+    var adminPlatformId = new PlatformId(
+      Context.User.Username,
+      Context.User.Id.ToString(CultureInfo.InvariantCulture),
+      ApolloPlatform.Discord
+    );
+
+    var targetPlatformId = new PlatformId(
+      targetUser.Username,
+      targetUser.Id.ToString(CultureInfo.InvariantCulture),
+      ApolloPlatform.Discord
+    );
+
+    var result = await apolloServiceClient.GrantAccessAsync(adminPlatformId, targetPlatformId, CancellationToken.None);
+
+    if (result.IsFailed)
+    {
+      _ = await ModifyResponseAsync(message => message.Content = $"Failed to grant access: {result.GetErrorMessages(", ")}");
+      return;
+    }
+
+    _ = await ModifyResponseAsync(message => message.Content = $"Access granted to {targetUser.Username} ({targetUser.Id})");
+  }
+
+  [SlashCommand("revoke-access", "Revoke a user's access to Apollo (Admin only)")]
+  public async Task RevokeAccessAsync(
+    [SlashCommandParameter(Name = "user", Description = "The Discord user to revoke access from")] User targetUser
+  )
+  {
+    _ = await RespondAsync(InteractionCallback.DeferredMessage(MessageFlags.Ephemeral));
+
+    var adminPlatformId = new PlatformId(
+      Context.User.Username,
+      Context.User.Id.ToString(CultureInfo.InvariantCulture),
+      ApolloPlatform.Discord
+    );
+
+    var targetPlatformId = new PlatformId(
+      targetUser.Username,
+      targetUser.Id.ToString(CultureInfo.InvariantCulture),
+      ApolloPlatform.Discord
+    );
+
+    var result = await apolloServiceClient.RevokeAccessAsync(adminPlatformId, targetPlatformId, CancellationToken.None);
+
+    if (result.IsFailed)
+    {
+      _ = await ModifyResponseAsync(message => message.Content = $"Failed to revoke access: {result.GetErrorMessages(", ")}");
+      return;
+    }
+
+    _ = await ModifyResponseAsync(message => message.Content = $"Access revoked from {targetUser.Username} ({targetUser.Id})");
+  }
+}

--- a/src/Apollo.GRPC/Client/ApolloGrpcClient.cs
+++ b/src/Apollo.GRPC/Client/ApolloGrpcClient.cs
@@ -17,6 +17,7 @@ using CoreCreateToDoRequest = Apollo.Core.ToDos.Requests.CreateToDoRequest;
 using CoreNewMessageRequest = Apollo.Core.Conversations.NewMessageRequest;
 using GrpcCreateToDoRequest = Apollo.GRPC.Contracts.CreateToDoRequest;
 using GrpcGetPersonToDosRequest = Apollo.GRPC.Contracts.GetPersonToDosRequest;
+using GrpcManageAccessRequest = Apollo.GRPC.Contracts.ManageAccessRequest;
 using GrpcNewMessageRequest = Apollo.GRPC.Contracts.NewMessageRequest;
 using GrpcToDoDTO = Apollo.GRPC.Contracts.ToDoDTO;
 
@@ -106,6 +107,44 @@ public class ApolloGrpcClient : IApolloGrpcClient, IApolloServiceClient, IDispos
     }).ToArray();
 
     return Result.Ok<IEnumerable<ToDoSummary>>(summaries);
+  }
+
+  public async Task<Result<string>> GrantAccessAsync(PlatformId adminPlatformId, PlatformId targetPlatformId, CancellationToken cancellationToken = default)
+  {
+    var grpcRequest = new GrpcManageAccessRequest
+    {
+      AdminPlatform = adminPlatformId.Platform,
+      AdminPlatformUserId = adminPlatformId.PlatformUserId,
+      AdminUsername = adminPlatformId.Username,
+      TargetPlatform = targetPlatformId.Platform,
+      TargetPlatformUserId = targetPlatformId.PlatformUserId,
+      TargetUsername = targetPlatformId.Username
+    };
+
+    var grpcResult = await ApolloGrpcService.GrantAccessAsync(grpcRequest);
+
+    return grpcResult.IsSuccess
+      ? Result.Ok(grpcResult.Data ?? string.Empty)
+      : Result.Fail(string.Join("; ", grpcResult.Errors.Select(e => e.Message)));
+  }
+
+  public async Task<Result<string>> RevokeAccessAsync(PlatformId adminPlatformId, PlatformId targetPlatformId, CancellationToken cancellationToken = default)
+  {
+    var grpcRequest = new GrpcManageAccessRequest
+    {
+      AdminPlatform = adminPlatformId.Platform,
+      AdminPlatformUserId = adminPlatformId.PlatformUserId,
+      AdminUsername = adminPlatformId.Username,
+      TargetPlatform = targetPlatformId.Platform,
+      TargetPlatformUserId = targetPlatformId.PlatformUserId,
+      TargetUsername = targetPlatformId.Username
+    };
+
+    var grpcResult = await ApolloGrpcService.RevokeAccessAsync(grpcRequest);
+
+    return grpcResult.IsSuccess
+      ? Result.Ok(grpcResult.Data ?? string.Empty)
+      : Result.Fail(string.Join("; ", grpcResult.Errors.Select(e => e.Message)));
   }
 
   private static ToDo MapToDomain(GrpcToDoDTO dto)

--- a/src/Apollo.GRPC/Contracts/ManageAccessRequest.cs
+++ b/src/Apollo.GRPC/Contracts/ManageAccessRequest.cs
@@ -1,0 +1,49 @@
+using System.Runtime.Serialization;
+
+using Apollo.Domain.Common.Enums;
+using Apollo.Domain.People.ValueObjects;
+
+namespace Apollo.GRPC.Contracts;
+
+[DataContract]
+public sealed record ManageAccessRequest
+{
+  /// <summary>
+  /// The platform of the admin making the request.
+  /// </summary>
+  [DataMember(Order = 1)]
+  public required Platform AdminPlatform { get; init; }
+
+  /// <summary>
+  /// The platform user ID of the admin making the request.
+  /// </summary>
+  [DataMember(Order = 2)]
+  public required string AdminPlatformUserId { get; init; }
+
+  /// <summary>
+  /// The username of the admin making the request.
+  /// </summary>
+  [DataMember(Order = 3)]
+  public required string AdminUsername { get; init; }
+
+  /// <summary>
+  /// The platform of the target user whose access is being managed.
+  /// </summary>
+  [DataMember(Order = 4)]
+  public required Platform TargetPlatform { get; init; }
+
+  /// <summary>
+  /// The platform user ID of the target user whose access is being managed.
+  /// </summary>
+  [DataMember(Order = 5)]
+  public required string TargetPlatformUserId { get; init; }
+
+  /// <summary>
+  /// The username of the target user whose access is being managed.
+  /// </summary>
+  [DataMember(Order = 6)]
+  public required string TargetUsername { get; init; }
+
+  public PlatformId ToAdminPlatformId() => new(AdminUsername, AdminPlatformUserId, AdminPlatform);
+  public PlatformId ToTargetPlatformId() => new(TargetUsername, TargetPlatformUserId, TargetPlatform);
+}

--- a/src/Apollo.GRPC/Service/IApolloGrpcService.cs
+++ b/src/Apollo.GRPC/Service/IApolloGrpcService.cs
@@ -27,4 +27,10 @@ public interface IApolloGrpcService
 
   [OperationContract]
   Task<GrpcResult<string>> DeleteToDoAsync(DeleteToDoRequest request);
+
+  [OperationContract]
+  Task<GrpcResult<string>> GrantAccessAsync(ManageAccessRequest request);
+
+  [OperationContract]
+  Task<GrpcResult<string>> RevokeAccessAsync(ManageAccessRequest request);
 }


### PR DESCRIPTION
Implement admin-only slash commands for managing user access to Apollo:
- /grant-access @user - grants access to a Discord user
- /revoke-access @user - revokes access from a Discord user

Only the super admin (configured via SuperAdminConfig__DiscordUserId) can execute these commands. Super admin cannot revoke their own access.