### PR TITLE
chore: incremental improvements — Caddy, error handling, and cleanup

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,22 @@
+# Apollo reverse proxy
+#
+# Dev default: http://localhost:8083
+# Production: set CADDY_HOST=apollothecat.app and CADDY_HTTP_PORT/CADDY_HTTPS_PORT
+# to 80/443 in docker-compose (or via .env). Caddy handles ACME/Let's Encrypt
+# automatically when a real domain is used.
+
+{
+  http_port  {$CADDY_HTTP_PORT:-8083}
+  https_port {$CADDY_HTTPS_PORT:-8443}
+}
+
+{$CADDY_HOST:-localhost:8083} {
+  # Main API + SPA
+  reverse_proxy apollo-api:5144
+
+  # Discord service endpoints (exposed under /discord/)
+  handle /discord/* {
+    uri strip_prefix /discord
+    reverse_proxy apollo-discord:5145
+  }
+}

--- a/Caddyfile
+++ b/Caddyfile
@@ -10,7 +10,7 @@
   https_port {$CADDY_HTTPS_PORT:-8443}
 }
 
-{$CADDY_HOST:-localhost:8083} {
+{$CADDY_HOST:-localhost} {
   # Main API + SPA
   reverse_proxy apollo-api:5144
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,11 +1,27 @@
 services:
+  caddy:
+    image: caddy:alpine
+    restart: unless-stopped
+    ports:
+      - "${CADDY_HTTP_PORT:-8083}:8083"
+      - "${CADDY_HTTPS_PORT:-8443}:8443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - apollo-api
+      - apollo-discord
+    networks:
+      - apollo
+
   apollo-api:
     image: apollo-api
     build:
       context: .
       dockerfile: src/Apollo.API/Dockerfile
-    ports:
-      - 5144:5144
+    expose:
+      - "5144"
     env_file:
       - .env
     depends_on:
@@ -19,8 +35,8 @@ services:
     build:
       context: .
       dockerfile: src/Apollo.Discord/Dockerfile
-    ports:
-      - 5145:5145
+    expose:
+      - "5145"
     env_file:
       - .env
     depends_on:
@@ -34,8 +50,8 @@ services:
     build:
       context: .
       dockerfile: src/Apollo.Service/Dockerfile
-    ports:
-      - 5270:5270
+    expose:
+      - "5270"
     env_file:
       - .env
     depends_on:
@@ -77,6 +93,8 @@ services:
 volumes:
   pgsql_data:
   redis_data:
+  caddy_data:
+  caddy_config:
 
 networks:
   apollo:

--- a/src/Apollo.API/Controllers/SetupController.cs
+++ b/src/Apollo.API/Controllers/SetupController.cs
@@ -1,5 +1,7 @@
 using Apollo.Application.Configuration;
 
+using Apollo.Core;
+
 using FluentResults;
 
 using MediatR;
@@ -150,7 +152,7 @@ public sealed class SetupController(IMediator mediator) : ControllerBase
 
   private static string GetErrorMessage(ResultBase result)
   {
-    return result.Errors.Count > 0 ? result.Errors[0].Message : "Unknown error";
+    return result.GetErrorMessages();
   }
 }
 

--- a/src/Apollo.API/Dashboard/DashboardConnectionTracker.cs
+++ b/src/Apollo.API/Dashboard/DashboardConnectionTracker.cs
@@ -4,8 +4,8 @@ public sealed class DashboardConnectionTracker
 {
   private int _connectionCount;
 
-  public int ConnectionCount => _connectionCount;
-  public bool HasConnections => _connectionCount > 0;
+  public int ConnectionCount => Volatile.Read(ref _connectionCount);
+  public bool HasConnections => Volatile.Read(ref _connectionCount) > 0;
 
   public void Connected()
   {

--- a/src/Apollo.API/Dashboard/DashboardOverviewService.cs
+++ b/src/Apollo.API/Dashboard/DashboardOverviewService.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 
 using Apollo.Application.Configuration;
+using Apollo.Core;
 using Apollo.Core.Dashboard;
 
 using MediatR;
@@ -18,7 +19,7 @@ public sealed class DashboardOverviewService(
 
     if (statusResult.IsFailed)
     {
-      throw new InvalidOperationException(statusResult.Errors.Count > 0 ? statusResult.Errors[0].Message : "Unknown error");
+      throw new InvalidOperationException(statusResult.GetErrorMessages());
     }
 
     var now = timeProvider.GetUtcNow().UtcDateTime;

--- a/src/Apollo.API/Program.cs
+++ b/src/Apollo.API/Program.cs
@@ -36,14 +36,6 @@ _ = webAppBuilder.Services.AddMediatR(cfg =>
   cfg.RegisterServicesFromAssemblyContaining<GetInitializationStatusQueryHandler>()
 );
 
-// Disable DI validate-on-build: Apollo.API is a gateway — not all registered handlers
-// (from transitive assembly scans) need resolvable dependencies in this host.
-webAppBuilder.Host.UseDefaultServiceProvider(options =>
-{
-  options.ValidateOnBuild = false;
-  options.ValidateScopes = webAppBuilder.Environment.IsDevelopment();
-});
-
 WebApplication app = webAppBuilder.Build();
 
 if (app.Environment.IsDevelopment())

--- a/src/Apollo.API/Program.cs
+++ b/src/Apollo.API/Program.cs
@@ -1,8 +1,11 @@
 using Apollo.Application.Configuration;
 using Apollo.Cache;
 using Apollo.API.Dashboard;
+using Apollo.Core.Configuration;
 using Apollo.Database;
 using Apollo.GRPC;
+using FluentResults;
+using MediatR;
 
 
 WebApplicationBuilder webAppBuilder = WebApplication.CreateBuilder(args);
@@ -28,13 +31,17 @@ _ = webAppBuilder.Services
   .AddScoped<IDashboardOverviewService, DashboardOverviewService>()
   .AddSingleton(TimeProvider.System);
 
-// Register MediatR scoped to only the configuration handlers.
-// Apollo.API is a pure REST gateway and only needs configuration CQRS handlers.
-// We register handlers explicitly to avoid pulling in AI-dependent handlers
-// from the full Apollo.Application assembly scan.
+// Register only the specific MediatR handlers Apollo.API needs.
+// Apollo.Application lives in the same assembly as AI/scheduler-dependent handlers,
+// so we cannot use RegisterServicesFromAssemblyContaining — it would pull in handlers
+// whose dependencies (IApolloAIAgent, IToDoReminderScheduler) are not registered here.
 _ = webAppBuilder.Services.AddMediatR(cfg =>
-  cfg.RegisterServicesFromAssemblyContaining<GetInitializationStatusQueryHandler>()
-);
+  cfg.RegisterServicesFromAssemblyContaining<DashboardConnectionTracker>());
+_ = webAppBuilder.Services
+  .AddTransient<IRequestHandler<GetInitializationStatusQuery, Result<InitializationStatus>>, GetInitializationStatusQueryHandler>()
+  .AddTransient<IRequestHandler<UpdateAiConfigurationCommand, Result<ConfigurationData>>, UpdateAiConfigurationCommandHandler>()
+  .AddTransient<IRequestHandler<UpdateDiscordConfigurationCommand, Result<ConfigurationData>>, UpdateDiscordConfigurationCommandHandler>()
+  .AddTransient<IRequestHandler<UpdateSuperAdminConfigurationCommand, Result<ConfigurationData>>, UpdateSuperAdminConfigurationCommandHandler>();
 
 WebApplication app = webAppBuilder.Build();
 

--- a/src/Apollo.API/Program.cs
+++ b/src/Apollo.API/Program.cs
@@ -64,7 +64,9 @@ _ = app.MapHub<DashboardHub>("/hubs/dashboard");
 _ = app.MapMethods("{**path}", [HttpMethods.Get, HttpMethods.Head], async context =>
 #pragma warning restore ASP0018
 {
-  if (context.Request.Path.StartsWithSegments("/api") || context.Request.Path.StartsWithSegments("/hubs"))
+  if (context.Request.Path.StartsWithSegments("/api")
+    || context.Request.Path.StartsWithSegments("/hubs")
+    || context.Request.Path.StartsWithSegments("/assets"))
   {
     context.Response.StatusCode = StatusCodes.Status404NotFound;
     return;
@@ -84,7 +86,6 @@ _ = app.MapMethods("{**path}", [HttpMethods.Get, HttpMethods.Head], async contex
     return;
   }
 
-  context.Response.ContentType = "text/html; charset=utf-8";
   await context.Response.SendFileAsync(indexPath);
 });
 

--- a/src/Apollo.API/Program.cs
+++ b/src/Apollo.API/Program.cs
@@ -85,6 +85,7 @@ _ = app.MapMethods("{**path}", [HttpMethods.Get, HttpMethods.Head], async contex
     return;
   }
 
+  context.Response.ContentType = "text/html; charset=utf-8";
   await context.Response.SendFileAsync(indexPath);
 });
 

--- a/src/Apollo.Application/Configuration/Notifications/ConfigurationNotifications.cs
+++ b/src/Apollo.Application/Configuration/Notifications/ConfigurationNotifications.cs
@@ -1,0 +1,5 @@
+namespace Apollo.Application.Configuration.Notifications;
+
+public record AiConfigurationUpdatedNotification : INotification;
+public record DiscordConfigurationUpdatedNotification : INotification;
+public record SuperAdminConfigurationUpdatedNotification : INotification;

--- a/src/Apollo.Application/Configuration/UpdateAiConfigurationCommand.cs
+++ b/src/Apollo.Application/Configuration/UpdateAiConfigurationCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.Configuration.Notifications;
 using Apollo.Core.Configuration;
 
 using FluentResults;
@@ -17,16 +18,25 @@ public sealed record UpdateAiConfigurationCommand(
   string? ApiKey
 ) : IRequest<Result<ConfigurationData>>;
 
-public sealed class UpdateAiConfigurationCommandHandler(IConfigurationStore configurationStore)
+public sealed class UpdateAiConfigurationCommandHandler(IConfigurationStore configurationStore, IMediator mediator)
   : IRequestHandler<UpdateAiConfigurationCommand, Result<ConfigurationData>>
 {
   public async Task<Result<ConfigurationData>> Handle(UpdateAiConfigurationCommand request, CancellationToken cancellationToken = default)
   {
     try
     {
-      return string.IsNullOrWhiteSpace(request.ModelId) && string.IsNullOrWhiteSpace(request.Endpoint)
-        ? Result.Fail<ConfigurationData>("At least one of ModelId or Endpoint must be provided.")
-        : await configurationStore.UpdateAiAsync(request.ModelId, request.Endpoint, request.ApiKey, cancellationToken);
+      if (string.IsNullOrWhiteSpace(request.ModelId) && string.IsNullOrWhiteSpace(request.Endpoint))
+      {
+        return Result.Fail<ConfigurationData>("At least one of ModelId or Endpoint must be provided.");
+      }
+
+      var result = await configurationStore.UpdateAiAsync(request.ModelId, request.Endpoint, request.ApiKey, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new AiConfigurationUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/Configuration/UpdateDiscordConfigurationCommand.cs
+++ b/src/Apollo.Application/Configuration/UpdateDiscordConfigurationCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.Configuration.Notifications;
 using Apollo.Core.Configuration;
 
 using FluentResults;
@@ -17,16 +18,25 @@ public sealed record UpdateDiscordConfigurationCommand(
   string? BotName
 ) : IRequest<Result<ConfigurationData>>;
 
-public sealed class UpdateDiscordConfigurationCommandHandler(IConfigurationStore configurationStore)
+public sealed class UpdateDiscordConfigurationCommandHandler(IConfigurationStore configurationStore, IMediator mediator)
   : IRequestHandler<UpdateDiscordConfigurationCommand, Result<ConfigurationData>>
 {
   public async Task<Result<ConfigurationData>> Handle(UpdateDiscordConfigurationCommand request, CancellationToken cancellationToken = default)
   {
     try
     {
-      return string.IsNullOrWhiteSpace(request.Token) && string.IsNullOrWhiteSpace(request.PublicKey)
-        ? Result.Fail<ConfigurationData>("At least one of Token or PublicKey must be provided.")
-        : await configurationStore.UpdateDiscordAsync(request.Token, request.PublicKey, request.BotName, cancellationToken);
+      if (string.IsNullOrWhiteSpace(request.Token) && string.IsNullOrWhiteSpace(request.PublicKey))
+      {
+        return Result.Fail<ConfigurationData>("At least one of Token or PublicKey must be provided.");
+      }
+
+      var result = await configurationStore.UpdateDiscordAsync(request.Token, request.PublicKey, request.BotName, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new DiscordConfigurationUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/Configuration/UpdateSuperAdminConfigurationCommand.cs
+++ b/src/Apollo.Application/Configuration/UpdateSuperAdminConfigurationCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.Configuration.Notifications;
 using Apollo.Core.Configuration;
 
 using FluentResults;
@@ -13,16 +14,25 @@ public sealed record UpdateSuperAdminConfigurationCommand(
   string? DiscordUserId
 ) : IRequest<Result<ConfigurationData>>;
 
-public sealed class UpdateSuperAdminConfigurationCommandHandler(IConfigurationStore configurationStore)
+public sealed class UpdateSuperAdminConfigurationCommandHandler(IConfigurationStore configurationStore, IMediator mediator)
   : IRequestHandler<UpdateSuperAdminConfigurationCommand, Result<ConfigurationData>>
 {
   public async Task<Result<ConfigurationData>> Handle(UpdateSuperAdminConfigurationCommand request, CancellationToken cancellationToken = default)
   {
     try
     {
-      return string.IsNullOrWhiteSpace(request.DiscordUserId)
-        ? Result.Fail<ConfigurationData>("DiscordUserId must be provided.")
-        : await configurationStore.UpdateSuperAdminAsync(request.DiscordUserId, cancellationToken);
+      if (string.IsNullOrWhiteSpace(request.DiscordUserId))
+      {
+        return Result.Fail<ConfigurationData>("DiscordUserId must be provided.");
+      }
+
+      var result = await configurationStore.UpdateSuperAdminAsync(request.DiscordUserId, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new SuperAdminConfigurationUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/Conversations/Notifications/ConversationNotifications.cs
+++ b/src/Apollo.Application/Conversations/Notifications/ConversationNotifications.cs
@@ -1,0 +1,5 @@
+namespace Apollo.Application.Conversations.Notifications;
+
+public record ConversationCreatedNotification : INotification;
+public record MessageAddedNotification : INotification;
+public record ReplyAddedNotification : INotification;

--- a/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
+++ b/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
@@ -74,19 +74,11 @@ public sealed class ProcessIncomingMessageCommandHandler(
 
   private async Task<Result<Conversation>> GetOrCreateConversationWithMessageAsync(Person person, string messageContent, CancellationToken cancellationToken)
   {
-    var existingConvoResult = await conversationStore.GetConversationByPersonIdAsync(person.Id, cancellationToken);
-    var convoResult = existingConvoResult.IsSuccess
-      ? existingConvoResult
-      : await conversationStore.CreateAsync(person.Id, cancellationToken);
+    var convoResult = await conversationStore.GetOrCreateConversationByPersonIdAsync(person.Id, cancellationToken);
 
     if (convoResult.IsFailed)
     {
       return Result.Fail<Conversation>("Unable to fetch conversation.");
-    }
-
-    if (existingConvoResult.IsFailed)
-    {
-      await mediator.Publish(new ConversationCreatedNotification(), cancellationToken);
     }
 
     convoResult = await conversationStore.AddMessageAsync(convoResult.Value.Id, new Content(messageContent), cancellationToken);

--- a/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
+++ b/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
@@ -247,7 +247,7 @@ public sealed class ProcessIncomingMessageCommandHandler(
 
   private ToolPlan LogParsingFailure(Guid personId, Result<ToolPlan> parseResult)
   {
-    var errorMsg = parseResult.Errors.Count > 0 ? parseResult.Errors[0].Message : "Unknown error";
+    var errorMsg = parseResult.GetErrorMessages();
     ConversationLogs.ToolPlanParsingFailed(logger, personId, errorMsg);
     return new ToolPlan();
   }

--- a/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
+++ b/src/Apollo.Application/Conversations/ProcessIncomingMessageCommand.cs
@@ -3,6 +3,7 @@ using Apollo.AI.Models;
 using Apollo.AI.Planning;
 using Apollo.AI.Requests;
 using Apollo.AI.Tooling;
+using Apollo.Application.Conversations.Notifications;
 using Apollo.Application.People;
 using Apollo.Application.Reminders;
 using Apollo.Application.ToDos;
@@ -73,16 +74,30 @@ public sealed class ProcessIncomingMessageCommandHandler(
 
   private async Task<Result<Conversation>> GetOrCreateConversationWithMessageAsync(Person person, string messageContent, CancellationToken cancellationToken)
   {
-    var convoResult = await conversationStore.GetOrCreateConversationByPersonIdAsync(person.Id, cancellationToken);
+    var existingConvoResult = await conversationStore.GetConversationByPersonIdAsync(person.Id, cancellationToken);
+    var convoResult = existingConvoResult.IsSuccess
+      ? existingConvoResult
+      : await conversationStore.CreateAsync(person.Id, cancellationToken);
 
     if (convoResult.IsFailed)
     {
       return Result.Fail<Conversation>("Unable to fetch conversation.");
     }
 
+    if (existingConvoResult.IsFailed)
+    {
+      await mediator.Publish(new ConversationCreatedNotification(), cancellationToken);
+    }
+
     convoResult = await conversationStore.AddMessageAsync(convoResult.Value.Id, new Content(messageContent), cancellationToken);
 
-    return convoResult.IsFailed ? Result.Fail<Conversation>("Unable to add message to conversation.") : convoResult;
+    if (convoResult.IsFailed)
+    {
+      return Result.Fail<Conversation>("Unable to add message to conversation.");
+    }
+
+    await mediator.Publish(new MessageAddedNotification(), cancellationToken);
+    return convoResult;
   }
 
   private async Task<string> ProcessWithAIAsync(Conversation conversation, Person person, CancellationToken cancellationToken)
@@ -166,7 +181,10 @@ public sealed class ProcessIncomingMessageCommandHandler(
     if (addReplyResult.IsFailed)
     {
       DataAccessLogs.UnableToSaveMessageToConversation(logger, conversation.Id.Value, response);
+      return;
     }
+
+    await mediator.Publish(new ReplyAddedNotification(), cancellationToken);
   }
 
   private Result<Reply> CreateReplyToUser(string response)

--- a/src/Apollo.Application/Dashboard/DashboardOverviewHandler.cs
+++ b/src/Apollo.Application/Dashboard/DashboardOverviewHandler.cs
@@ -1,0 +1,98 @@
+using Apollo.Application.Configuration.Notifications;
+using Apollo.Application.Conversations.Notifications;
+using Apollo.Application.People.Notifications;
+using Apollo.Application.ToDos.Notifications;
+using Apollo.Core.Dashboard;
+
+namespace Apollo.Application.Dashboard;
+
+public sealed class DashboardOverviewHandler(IDashboardUpdatePublisher publisher) :
+  INotificationHandler<AiConfigurationUpdatedNotification>,
+  INotificationHandler<DiscordConfigurationUpdatedNotification>,
+  INotificationHandler<SuperAdminConfigurationUpdatedNotification>,
+  INotificationHandler<ConversationCreatedNotification>,
+  INotificationHandler<MessageAddedNotification>,
+  INotificationHandler<ReplyAddedNotification>,
+  INotificationHandler<PersonCreatedNotification>,
+  INotificationHandler<PersonAccessGrantedNotification>,
+  INotificationHandler<PersonAccessRevokedNotification>,
+  INotificationHandler<ToDoCreatedNotification>,
+  INotificationHandler<ToDoUpdatedNotification>,
+  INotificationHandler<ToDoCompletedNotification>,
+  INotificationHandler<ToDoDeletedNotification>,
+  INotificationHandler<ToDoPriorityUpdatedNotification>,
+  INotificationHandler<ToDoEnergyUpdatedNotification>,
+  INotificationHandler<ToDoInterestUpdatedNotification>,
+  INotificationHandler<ReminderCreatedNotification>,
+  INotificationHandler<ReminderLinkedToToDoNotification>,
+  INotificationHandler<ReminderUnlinkedFromToDoNotification>,
+  INotificationHandler<ReminderSentNotification>,
+  INotificationHandler<ReminderAcknowledgedNotification>,
+  INotificationHandler<ReminderDeletedNotification>
+{
+  public Task Handle(AiConfigurationUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(DiscordConfigurationUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(SuperAdminConfigurationUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ConversationCreatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(MessageAddedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReplyAddedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(PersonCreatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(PersonAccessGrantedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(PersonAccessRevokedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoCreatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoCompletedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoDeletedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoPriorityUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoEnergyUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ToDoInterestUpdatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderCreatedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderLinkedToToDoNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderUnlinkedFromToDoNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderSentNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderAcknowledgedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+
+  public Task Handle(ReminderDeletedNotification notification, CancellationToken cancellationToken) =>
+    publisher.PublishOverviewUpdatedAsync(cancellationToken);
+}

--- a/src/Apollo.Application/People/GetOrCreatePersonByPlatformIdQuery.cs
+++ b/src/Apollo.Application/People/GetOrCreatePersonByPlatformIdQuery.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.People.Notifications;
 using Apollo.Core.People;
 using Apollo.Domain.People.Models;
 using Apollo.Domain.People.ValueObjects;
@@ -8,12 +9,23 @@ namespace Apollo.Application.People;
 
 public sealed record GetOrCreatePersonByPlatformIdQuery(PlatformId PlatformId) : IRequest<Result<Person>>;
 
-public sealed class GetOrCreatePersonByPlatformIdQueryHandler(IPersonStore personStore)
+public sealed class GetOrCreatePersonByPlatformIdQueryHandler(IPersonStore personStore, IMediator mediator)
   : IRequestHandler<GetOrCreatePersonByPlatformIdQuery, Result<Person>>
 {
   public async Task<Result<Person>> Handle(GetOrCreatePersonByPlatformIdQuery request, CancellationToken cancellationToken)
   {
     var userResult = await personStore.GetByPlatformIdAsync(request.PlatformId, cancellationToken);
-    return userResult.IsSuccess ? userResult : await personStore.CreateByPlatformIdAsync(request.PlatformId, cancellationToken);
+    if (userResult.IsSuccess)
+    {
+      return userResult;
+    }
+
+    var createResult = await personStore.CreateByPlatformIdAsync(request.PlatformId, cancellationToken);
+    if (createResult.IsSuccess)
+    {
+      await mediator.Publish(new PersonCreatedNotification(), cancellationToken);
+    }
+
+    return createResult;
   }
 }

--- a/src/Apollo.Application/People/GrantPersonAccessCommand.cs
+++ b/src/Apollo.Application/People/GrantPersonAccessCommand.cs
@@ -1,0 +1,24 @@
+using Apollo.Application.People.Notifications;
+using Apollo.Core.People;
+using Apollo.Domain.People.ValueObjects;
+
+using FluentResults;
+
+namespace Apollo.Application.People;
+
+public sealed record GrantPersonAccessCommand(PersonId PersonId) : IRequest<Result>;
+
+public sealed class GrantPersonAccessCommandHandler(IPersonStore personStore, IMediator mediator)
+  : IRequestHandler<GrantPersonAccessCommand, Result>
+{
+  public async Task<Result> Handle(GrantPersonAccessCommand request, CancellationToken cancellationToken)
+  {
+    var result = await personStore.GrantAccessAsync(request.PersonId, cancellationToken);
+    if (result.IsSuccess)
+    {
+      await mediator.Publish(new PersonAccessGrantedNotification(), cancellationToken);
+    }
+
+    return result;
+  }
+}

--- a/src/Apollo.Application/People/Notifications/PeopleNotifications.cs
+++ b/src/Apollo.Application/People/Notifications/PeopleNotifications.cs
@@ -1,0 +1,5 @@
+namespace Apollo.Application.People.Notifications;
+
+public record PersonCreatedNotification : INotification;
+public record PersonAccessGrantedNotification : INotification;
+public record PersonAccessRevokedNotification : INotification;

--- a/src/Apollo.Application/People/PersonPlugin.cs
+++ b/src/Apollo.Application/People/PersonPlugin.cs
@@ -83,7 +83,7 @@ public class PersonPlugin(IPersonStore personStore, PersonConfig personConfig, P
       var result = await personStore.SetDailyTaskCountAsync(personId, dailyTaskCount);
 
       return result.IsFailed
-        ? $"Failed to set daily task count: {(result.Errors.Count > 0 ? result.Errors[0].Message : "Unknown error")}"
+        ? $"Failed to set daily task count: {result.GetErrorMessages()}"
         : $"Successfully set your daily task count to {count} tasks.";
     }
     catch (Exception ex)
@@ -102,7 +102,7 @@ public class PersonPlugin(IPersonStore personStore, PersonConfig personConfig, P
 
       if (personResult.IsFailed)
       {
-        return $"Failed to retrieve daily task count: {(personResult.Errors.Count > 0 ? personResult.Errors[0].Message : "Unknown error")}";
+        return $"Failed to retrieve daily task count: {personResult.GetErrorMessages()}";
       }
 
       var person = personResult.Value;

--- a/src/Apollo.Application/People/RevokePersonAccessCommand.cs
+++ b/src/Apollo.Application/People/RevokePersonAccessCommand.cs
@@ -1,0 +1,24 @@
+using Apollo.Application.People.Notifications;
+using Apollo.Core.People;
+using Apollo.Domain.People.ValueObjects;
+
+using FluentResults;
+
+namespace Apollo.Application.People;
+
+public sealed record RevokePersonAccessCommand(PersonId PersonId) : IRequest<Result>;
+
+public sealed class RevokePersonAccessCommandHandler(IPersonStore personStore, IMediator mediator)
+  : IRequestHandler<RevokePersonAccessCommand, Result>
+{
+  public async Task<Result> Handle(RevokePersonAccessCommand request, CancellationToken cancellationToken)
+  {
+    var result = await personStore.RevokeAccessAsync(request.PersonId, cancellationToken);
+    if (result.IsSuccess)
+    {
+      await mediator.Publish(new PersonAccessRevokedNotification(), cancellationToken);
+    }
+
+    return result;
+  }
+}

--- a/src/Apollo.Application/Reminders/AcknowledgeReminderCommand.cs
+++ b/src/Apollo.Application/Reminders/AcknowledgeReminderCommand.cs
@@ -1,0 +1,25 @@
+using Apollo.Application.ToDos.Notifications;
+using Apollo.Core.ToDos;
+using Apollo.Domain.ToDos.ValueObjects;
+
+using FluentResults;
+
+namespace Apollo.Application.Reminders;
+
+public sealed record AcknowledgeReminderCommand(ReminderId ReminderId) : IRequest<Result>;
+
+public sealed class AcknowledgeReminderCommandHandler(
+  IReminderStore reminderStore,
+  IMediator mediator) : IRequestHandler<AcknowledgeReminderCommand, Result>
+{
+  public async Task<Result> Handle(AcknowledgeReminderCommand request, CancellationToken cancellationToken)
+  {
+    var result = await reminderStore.AcknowledgeAsync(request.ReminderId, cancellationToken);
+    if (result.IsSuccess)
+    {
+      await mediator.Publish(new ReminderAcknowledgedNotification(), cancellationToken);
+    }
+
+    return result;
+  }
+}

--- a/src/Apollo.Application/Reminders/CancelReminderCommand.cs
+++ b/src/Apollo.Application/Reminders/CancelReminderCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.ToDos;
 using Apollo.Domain.People.ValueObjects;
@@ -15,7 +16,8 @@ public sealed record CancelReminderCommand(
 
 public sealed class CancelReminderCommandHandler(
   IReminderStore reminderStore,
-  IToDoReminderScheduler toDoReminderScheduler) : IRequestHandler<CancelReminderCommand, Result>
+  IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator) : IRequestHandler<CancelReminderCommand, Result>
 {
   public async Task<Result> Handle(CancelReminderCommand request, CancellationToken cancellationToken)
   {
@@ -34,7 +36,18 @@ public sealed class CancelReminderCommandHandler(
       }
 
       var linkedResult = await EnsureNotLinkedToToDosAsync(request.ReminderId, cancellationToken);
-      return linkedResult.IsFailed ? linkedResult : await DeleteReminderAndCleanupJobAsync(reminderResult.Value, cancellationToken);
+      if (linkedResult.IsFailed)
+      {
+        return linkedResult;
+      }
+
+      var deleteResult = await DeleteReminderAndCleanupJobAsync(reminderResult.Value, cancellationToken);
+      if (deleteResult.IsSuccess)
+      {
+        await mediator.Publish(new ReminderDeletedNotification(), cancellationToken);
+      }
+
+      return deleteResult;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/Reminders/MarkReminderSentCommand.cs
+++ b/src/Apollo.Application/Reminders/MarkReminderSentCommand.cs
@@ -1,0 +1,25 @@
+using Apollo.Application.ToDos.Notifications;
+using Apollo.Core.ToDos;
+using Apollo.Domain.ToDos.ValueObjects;
+
+using FluentResults;
+
+namespace Apollo.Application.Reminders;
+
+public sealed record MarkReminderSentCommand(ReminderId ReminderId) : IRequest<Result>;
+
+public sealed class MarkReminderSentCommandHandler(
+  IReminderStore reminderStore,
+  IMediator mediator) : IRequestHandler<MarkReminderSentCommand, Result>
+{
+  public async Task<Result> Handle(MarkReminderSentCommand request, CancellationToken cancellationToken)
+  {
+    var result = await reminderStore.MarkAsSentAsync(request.ReminderId, cancellationToken);
+    if (result.IsSuccess)
+    {
+      await mediator.Publish(new ReminderSentNotification(), cancellationToken);
+    }
+
+    return result;
+  }
+}

--- a/src/Apollo.Application/ToDos/AddReminderCommand.cs
+++ b/src/Apollo.Application/ToDos/AddReminderCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.ToDos;
 using Apollo.Domain.ToDos.Models;
@@ -15,7 +16,8 @@ public sealed record AddReminderCommand(
 public sealed class AddReminderCommandHandler(
   IToDoStore toDoStore,
   IReminderStore reminderStore,
-  IToDoReminderScheduler toDoReminderScheduler) : IRequestHandler<AddReminderCommand, Result<Reminder>>
+  IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator) : IRequestHandler<AddReminderCommand, Result<Reminder>>
 {
   public async Task<Result<Reminder>> Handle(AddReminderCommand request, CancellationToken cancellationToken)
   {
@@ -34,6 +36,14 @@ public sealed class AddReminderCommandHandler(
       }
 
       var createResult = await CreateAndLinkReminderAsync(toDoResult.Value, request.ReminderDate, jobResult.Value, cancellationToken);
+      if (createResult.IsFailed)
+      {
+        return createResult;
+      }
+
+      await mediator.Publish(new ReminderCreatedNotification(), cancellationToken);
+      await mediator.Publish(new ReminderLinkedToToDoNotification(), cancellationToken);
+
       return (await EnsureJobExistsAsync(request.ReminderDate, cancellationToken), createResult) switch
       {
         (_, { IsFailed: true } createFailed) => createFailed,

--- a/src/Apollo.Application/ToDos/CompleteToDoCommand.cs
+++ b/src/Apollo.Application/ToDos/CompleteToDoCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.Logging;
 using Apollo.Core.ToDos;
@@ -14,6 +15,7 @@ public sealed class CompleteToDoCommandHandler(
   IToDoStore toDoStore,
   IReminderStore reminderStore,
   IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator,
   ILogger<CompleteToDoCommandHandler> logger) : IRequestHandler<CompleteToDoCommand, Result>
 {
   public async Task<Result> Handle(CompleteToDoCommand request, CancellationToken cancellationToken)
@@ -27,6 +29,8 @@ public sealed class CompleteToDoCommandHandler(
       {
         return completeResult;
       }
+
+      await mediator.Publish(new ToDoCompletedNotification(), cancellationToken);
 
       var cleanupResult = await CleanupRemindersForCompletedToDoAsync(linkedReminders, request.ToDoId, cancellationToken);
       return cleanupResult.IsFailed ? cleanupResult : completeResult;

--- a/src/Apollo.Application/ToDos/CreateReminderCommand.cs
+++ b/src/Apollo.Application/ToDos/CreateReminderCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.ToDos;
 using Apollo.Domain.People.ValueObjects;
@@ -16,7 +17,8 @@ public sealed record CreateReminderCommand(
 
 public sealed class CreateReminderCommandHandler(
   IReminderStore reminderStore,
-  IToDoReminderScheduler toDoReminderScheduler) : IRequestHandler<CreateReminderCommand, Result<Reminder>>
+  IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator) : IRequestHandler<CreateReminderCommand, Result<Reminder>>
 {
   public async Task<Result<Reminder>> Handle(CreateReminderCommand request, CancellationToken cancellationToken)
   {
@@ -39,6 +41,8 @@ public sealed class CreateReminderCommandHandler(
       {
         return createResult;
       }
+
+      await mediator.Publish(new ReminderCreatedNotification(), cancellationToken);
 
       var ensureResult = await EnsureJobExistsAsync(request.ReminderDate, cancellationToken);
       return ensureResult.IsFailed

--- a/src/Apollo.Application/ToDos/CreateToDoCommand.cs
+++ b/src/Apollo.Application/ToDos/CreateToDoCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.ToDos;
 using Apollo.Domain.Common.Enums;
@@ -21,7 +22,8 @@ public sealed record CreateToDoCommand(
 public sealed class CreateToDoCommandHandler(
   IToDoStore toDoStore,
   IReminderStore reminderStore,
-  IToDoReminderScheduler toDoReminderScheduler) : IRequestHandler<CreateToDoCommand, Result<ToDo>>
+  IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator) : IRequestHandler<CreateToDoCommand, Result<ToDo>>
 {
   public async Task<Result<ToDo>> Handle(CreateToDoCommand request, CancellationToken cancellationToken)
   {
@@ -35,6 +37,8 @@ public sealed class CreateToDoCommandHandler(
       {
         return createResult;
       }
+
+      await mediator.Publish(new ToDoCreatedNotification(), cancellationToken);
 
       if (request.ReminderDate.HasValue)
       {

--- a/src/Apollo.Application/ToDos/DeleteToDoCommand.cs
+++ b/src/Apollo.Application/ToDos/DeleteToDoCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.Logging;
 using Apollo.Core.ToDos;
@@ -14,6 +15,7 @@ public sealed class DeleteToDoCommandHandler(
   IToDoStore toDoStore,
   IReminderStore reminderStore,
   IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator,
   ILogger<DeleteToDoCommandHandler> logger) : IRequestHandler<DeleteToDoCommand, Result>
 {
   public async Task<Result> Handle(DeleteToDoCommand request, CancellationToken cancellationToken)
@@ -27,6 +29,8 @@ public sealed class DeleteToDoCommandHandler(
       {
         return deleteResult;
       }
+
+      await mediator.Publish(new ToDoDeletedNotification(), cancellationToken);
 
       var cleanupResult = await CleanupRemindersForDeletedToDoAsync(linkedReminders, request.ToDoId, cancellationToken);
       return cleanupResult.IsFailed ? cleanupResult : deleteResult;

--- a/src/Apollo.Application/ToDos/Notifications/ToDoNotifications.cs
+++ b/src/Apollo.Application/ToDos/Notifications/ToDoNotifications.cs
@@ -1,0 +1,16 @@
+namespace Apollo.Application.ToDos.Notifications;
+
+public record ToDoCreatedNotification : INotification;
+public record ToDoUpdatedNotification : INotification;
+public record ToDoCompletedNotification : INotification;
+public record ToDoDeletedNotification : INotification;
+public record ToDoPriorityUpdatedNotification : INotification;
+public record ToDoEnergyUpdatedNotification : INotification;
+public record ToDoInterestUpdatedNotification : INotification;
+
+public record ReminderCreatedNotification : INotification;
+public record ReminderLinkedToToDoNotification : INotification;
+public record ReminderUnlinkedFromToDoNotification : INotification;
+public record ReminderSentNotification : INotification;
+public record ReminderAcknowledgedNotification : INotification;
+public record ReminderDeletedNotification : INotification;

--- a/src/Apollo.Application/ToDos/RemoveReminderCommand.cs
+++ b/src/Apollo.Application/ToDos/RemoveReminderCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.ToDos;
 using Apollo.Domain.ToDos.Models;
@@ -14,7 +15,8 @@ public sealed record RemoveReminderCommand(
 
 public sealed class RemoveReminderCommandHandler(
   IReminderStore reminderStore,
-  IToDoReminderScheduler toDoReminderScheduler) : IRequestHandler<RemoveReminderCommand, Result>
+  IToDoReminderScheduler toDoReminderScheduler,
+  IMediator mediator) : IRequestHandler<RemoveReminderCommand, Result>
 {
   public async Task<Result> Handle(RemoveReminderCommand request, CancellationToken cancellationToken)
   {
@@ -31,6 +33,8 @@ public sealed class RemoveReminderCommandHandler(
       {
         return unlinkResult;
       }
+
+      await mediator.Publish(new ReminderUnlinkedFromToDoNotification(), cancellationToken);
 
       await CleanupOrphanedReminderAsync(reminderResult.Value, cancellationToken);
       return Result.Ok();

--- a/src/Apollo.Application/ToDos/SetAllToDosAttributeCommand.cs
+++ b/src/Apollo.Application/ToDos/SetAllToDosAttributeCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core;
 using Apollo.Core.Logging;
 using Apollo.Core.ToDos;
@@ -18,6 +19,7 @@ public sealed record SetAllToDosAttributeCommand(
 
 public sealed class SetAllToDosAttributeCommandHandler(
   IToDoStore toDoStore,
+  IMediator mediator,
   ILogger<SetAllToDosAttributeCommandHandler> logger) : IRequestHandler<SetAllToDosAttributeCommand, Result<int>>
 {
   public async Task<Result<int>> Handle(SetAllToDosAttributeCommand request, CancellationToken cancellationToken)
@@ -43,6 +45,7 @@ public sealed class SetAllToDosAttributeCommandHandler(
         }
 
         var (updated, errors) = await UpdateAttributesAsync(todoId, request, cancellationToken);
+
         if (updated)
         {
           updatedCount++;
@@ -109,6 +112,7 @@ public sealed class SetAllToDosAttributeCommandHandler(
       else
       {
         updated = true;
+        await mediator.Publish(new ToDoPriorityUpdatedNotification(), cancellationToken);
       }
     }
 
@@ -122,6 +126,7 @@ public sealed class SetAllToDosAttributeCommandHandler(
       else
       {
         updated = true;
+        await mediator.Publish(new ToDoEnergyUpdatedNotification(), cancellationToken);
       }
     }
 
@@ -135,6 +140,7 @@ public sealed class SetAllToDosAttributeCommandHandler(
       else
       {
         updated = true;
+        await mediator.Publish(new ToDoInterestUpdatedNotification(), cancellationToken);
       }
     }
 

--- a/src/Apollo.Application/ToDos/SetToDoEnergyCommand.cs
+++ b/src/Apollo.Application/ToDos/SetToDoEnergyCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core.ToDos;
 using Apollo.Domain.People.ValueObjects;
 using Apollo.Domain.ToDos.ValueObjects;
@@ -12,16 +13,25 @@ public sealed record SetToDoEnergyCommand(
   Energy Energy
 ) : IRequest<Result>;
 
-public sealed class SetToDoEnergyCommandHandler(IToDoStore toDoStore) : IRequestHandler<SetToDoEnergyCommand, Result>
+public sealed class SetToDoEnergyCommandHandler(IToDoStore toDoStore, IMediator mediator) : IRequestHandler<SetToDoEnergyCommand, Result>
 {
   public async Task<Result> Handle(SetToDoEnergyCommand request, CancellationToken cancellationToken)
   {
     try
     {
       var ownershipResult = await VerifyOwnershipAsync(request.ToDoId, request.PersonId, cancellationToken);
-      return ownershipResult.IsFailed
-        ? ownershipResult
-        : await toDoStore.UpdateEnergyAsync(request.ToDoId, request.Energy, cancellationToken);
+      if (ownershipResult.IsFailed)
+      {
+        return ownershipResult;
+      }
+
+      var result = await toDoStore.UpdateEnergyAsync(request.ToDoId, request.Energy, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new ToDoEnergyUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/ToDos/SetToDoInterestCommand.cs
+++ b/src/Apollo.Application/ToDos/SetToDoInterestCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core.ToDos;
 using Apollo.Domain.People.ValueObjects;
 using Apollo.Domain.ToDos.ValueObjects;
@@ -12,16 +13,25 @@ public sealed record SetToDoInterestCommand(
   Interest Interest
 ) : IRequest<Result>;
 
-public sealed class SetToDoInterestCommandHandler(IToDoStore toDoStore) : IRequestHandler<SetToDoInterestCommand, Result>
+public sealed class SetToDoInterestCommandHandler(IToDoStore toDoStore, IMediator mediator) : IRequestHandler<SetToDoInterestCommand, Result>
 {
   public async Task<Result> Handle(SetToDoInterestCommand request, CancellationToken cancellationToken)
   {
     try
     {
       var ownershipResult = await VerifyOwnershipAsync(request.ToDoId, request.PersonId, cancellationToken);
-      return ownershipResult.IsFailed
-        ? ownershipResult
-        : await toDoStore.UpdateInterestAsync(request.ToDoId, request.Interest, cancellationToken);
+      if (ownershipResult.IsFailed)
+      {
+        return ownershipResult;
+      }
+
+      var result = await toDoStore.UpdateInterestAsync(request.ToDoId, request.Interest, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new ToDoInterestUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/ToDos/SetToDoPriorityCommand.cs
+++ b/src/Apollo.Application/ToDos/SetToDoPriorityCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core.ToDos;
 using Apollo.Domain.People.ValueObjects;
 using Apollo.Domain.ToDos.ValueObjects;
@@ -12,16 +13,25 @@ public sealed record SetToDoPriorityCommand(
   Priority Priority
 ) : IRequest<Result>;
 
-public sealed class SetToDoPriorityCommandHandler(IToDoStore toDoStore) : IRequestHandler<SetToDoPriorityCommand, Result>
+public sealed class SetToDoPriorityCommandHandler(IToDoStore toDoStore, IMediator mediator) : IRequestHandler<SetToDoPriorityCommand, Result>
 {
   public async Task<Result> Handle(SetToDoPriorityCommand request, CancellationToken cancellationToken)
   {
     try
     {
       var ownershipResult = await VerifyOwnershipAsync(request.ToDoId, request.PersonId, cancellationToken);
-      return ownershipResult.IsFailed
-        ? ownershipResult
-        : await toDoStore.UpdatePriorityAsync(request.ToDoId, request.Priority, cancellationToken);
+      if (ownershipResult.IsFailed)
+      {
+        return ownershipResult;
+      }
+
+      var result = await toDoStore.UpdatePriorityAsync(request.ToDoId, request.Priority, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new ToDoPriorityUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Application/ToDos/ToDoPlugin.cs
+++ b/src/Apollo.Application/ToDos/ToDoPlugin.cs
@@ -381,7 +381,7 @@ public sealed class ToDoPlugin(
 
       return result switch
       {
-        { IsFailed: true } => $"Failed to retrieve todos: {(result.Errors.Count > 0 ? result.Errors[0].Message : "Unknown error")}",
+        { IsFailed: true } => $"Failed to retrieve todos: {result.GetErrorMessages()}",
         _ when !result.Value.Any() => "You currently have no active todos.",
         _ => FormatToDosAsTable(result.Value)
       };
@@ -403,7 +403,7 @@ public sealed class ToDoPlugin(
 
       if (result.IsFailed)
       {
-        return $"Failed to generate daily plan: {(result.Errors.Count > 0 ? result.Errors[0].Message : "Unknown error")}";
+        return $"Failed to generate daily plan: {result.GetErrorMessages()}";
       }
 
       var plan = result.Value;

--- a/src/Apollo.Application/ToDos/UpdateToDoCommand.cs
+++ b/src/Apollo.Application/ToDos/UpdateToDoCommand.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.ToDos.Notifications;
 using Apollo.Core.ToDos;
 using Apollo.Domain.ToDos.ValueObjects;
 
@@ -10,13 +11,19 @@ public sealed record UpdateToDoCommand(
   Description Description
 ) : IRequest<Result>;
 
-public sealed class UpdateToDoCommandHandler(IToDoStore toDoStore) : IRequestHandler<UpdateToDoCommand, Result>
+public sealed class UpdateToDoCommandHandler(IToDoStore toDoStore, IMediator mediator) : IRequestHandler<UpdateToDoCommand, Result>
 {
   public async Task<Result> Handle(UpdateToDoCommand request, CancellationToken cancellationToken)
   {
     try
     {
-      return await toDoStore.UpdateAsync(request.ToDoId, request.Description, cancellationToken);
+      var result = await toDoStore.UpdateAsync(request.ToDoId, request.Description, cancellationToken);
+      if (result.IsSuccess)
+      {
+        await mediator.Publish(new ToDoUpdatedNotification(), cancellationToken);
+      }
+
+      return result;
     }
     catch (Exception ex)
     {

--- a/src/Apollo.Database/Configuration/ConfigurationStore.cs
+++ b/src/Apollo.Database/Configuration/ConfigurationStore.cs
@@ -1,5 +1,4 @@
 using Apollo.Core.Configuration;
-using Apollo.Core.Dashboard;
 using Apollo.Database.Configuration.Events;
 
 using FluentResults;
@@ -8,7 +7,7 @@ using Marten;
 
 namespace Apollo.Database.Configuration;
 
-public sealed class ConfigurationStore(IDocumentSession session, IDashboardUpdatePublisher dashboardUpdatePublisher) : IConfigurationStore
+public sealed class ConfigurationStore(IDocumentSession session) : IConfigurationStore
 {
   public async Task<Result<ConfigurationData>> GetAsync(CancellationToken cancellationToken = default)
   {
@@ -38,7 +37,6 @@ public sealed class ConfigurationStore(IDocumentSession session, IDashboardUpdat
         : session.Events.Append(ConfigurationId.Root, ev);
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var updated = await session.Events.AggregateStreamAsync<DbConfiguration>(ConfigurationId.Root, token: cancellationToken);
 
@@ -65,7 +63,6 @@ public sealed class ConfigurationStore(IDocumentSession session, IDashboardUpdat
         : session.Events.Append(ConfigurationId.Root, ev);
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var updated = await session.Events.AggregateStreamAsync<DbConfiguration>(ConfigurationId.Root, token: cancellationToken);
 
@@ -92,7 +89,6 @@ public sealed class ConfigurationStore(IDocumentSession session, IDashboardUpdat
         : session.Events.Append(ConfigurationId.Root, ev);
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var updated = await session.Events.AggregateStreamAsync<DbConfiguration>(ConfigurationId.Root, token: cancellationToken);
 

--- a/src/Apollo.Database/Conversations/ConversationStore.cs
+++ b/src/Apollo.Database/Conversations/ConversationStore.cs
@@ -1,6 +1,5 @@
 using Apollo.Core;
 using Apollo.Core.Conversations;
-using Apollo.Core.Dashboard;
 using Apollo.Database.Conversations.Events;
 using Apollo.Domain.Common.ValueObjects;
 using Apollo.Domain.Conversations.Models;
@@ -13,7 +12,7 @@ using Marten;
 
 namespace Apollo.Database.Conversations;
 
-public sealed class ConversationStore(IDocumentSession session, TimeProvider timeProvider, IDashboardUpdatePublisher dashboardUpdatePublisher) : IConversationStore
+public sealed class ConversationStore(IDocumentSession session, TimeProvider timeProvider) : IConversationStore
 {
   public async Task<Result<Conversation>> AddMessageAsync(ConversationId conversationId, Content message, CancellationToken cancellationToken = default)
   {
@@ -27,7 +26,6 @@ public sealed class ConversationStore(IDocumentSession session, TimeProvider tim
       });
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var conversation = await GetAsync(conversationId, cancellationToken);
 
@@ -51,7 +49,6 @@ public sealed class ConversationStore(IDocumentSession session, TimeProvider tim
       });
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var conversation = await GetAsync(conversationId, cancellationToken);
 
@@ -77,7 +74,6 @@ public sealed class ConversationStore(IDocumentSession session, TimeProvider tim
 
       _ = session.Events.StartStream<DbConversation>(conversationId, [ev]);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var newConversation = await session.Events.AggregateStreamAsync<DbConversation>(conversationId, token: cancellationToken);
 

--- a/src/Apollo.Database/People/PersonStore.cs
+++ b/src/Apollo.Database/People/PersonStore.cs
@@ -1,6 +1,5 @@
 using Apollo.Core;
 using Apollo.Core.Configuration;
-using Apollo.Core.Dashboard;
 using Apollo.Core.People;
 using Apollo.Database.People.Events;
 using Apollo.Domain.Common.Enums;
@@ -13,7 +12,7 @@ using Marten;
 
 namespace Apollo.Database.People;
 
-public sealed class PersonStore(IConfigurationStore configurationStore, IDocumentSession session, TimeProvider timeProvider, IPersonCache personCache, IDashboardUpdatePublisher dashboardUpdatePublisher) : IPersonStore
+public sealed class PersonStore(IConfigurationStore configurationStore, IDocumentSession session, TimeProvider timeProvider, IPersonCache personCache) : IPersonStore
 {
   public async Task<Result<Person>> CreateByPlatformIdAsync(PlatformId platformId, CancellationToken cancellationToken = default)
   {
@@ -41,7 +40,6 @@ public sealed class PersonStore(IConfigurationStore configurationStore, IDocumen
 
       _ = session.Events.StartStream<DbPerson>(id, events);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       var newPerson = await session.Events.AggregateStreamAsync<DbPerson>(id, token: cancellationToken);
 
@@ -140,7 +138,6 @@ public sealed class PersonStore(IConfigurationStore configurationStore, IDocumen
 
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       // Invalidate access cache after granting access
       _ = await personCache.InvalidateAccessAsync(id);
@@ -165,7 +162,6 @@ public sealed class PersonStore(IConfigurationStore configurationStore, IDocumen
       });
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
 
       // Invalidate access cache after revoking access
       _ = await personCache.InvalidateAccessAsync(id);

--- a/src/Apollo.Database/ToDos/ReminderStore.cs
+++ b/src/Apollo.Database/ToDos/ReminderStore.cs
@@ -1,5 +1,4 @@
 using Apollo.Core;
-using Apollo.Core.Dashboard;
 using Apollo.Core.ToDos;
 using Apollo.Database.ToDos.Events;
 using Apollo.Domain.People.ValueObjects;
@@ -12,7 +11,7 @@ using Marten;
 
 namespace Apollo.Database.ToDos;
 
-public sealed class ReminderStore(IDocumentSession session, TimeProvider timeProvider, IDashboardUpdatePublisher dashboardUpdatePublisher) : IReminderStore
+public sealed class ReminderStore(IDocumentSession session, TimeProvider timeProvider) : IReminderStore
 {
   public async Task<Result<Reminder>> CreateAsync(
     ReminderId id,
@@ -29,8 +28,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.StartStream<DbReminder>(id.Value, [ev]);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       var newReminder = await session.Events.AggregateStreamAsync<DbReminder>(id.Value, token: cancellationToken);
 
       return newReminder is null
@@ -115,8 +112,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.StartStream<DbToDoReminder>(linkId, [ev]);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -142,8 +137,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.Append(link.Id, ev);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -161,8 +154,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.Append(id.Value, ev);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -180,8 +171,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.Append(id.Value, ev);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -199,8 +188,6 @@ public sealed class ReminderStore(IDocumentSession session, TimeProvider timePro
 
       _ = session.Events.Append(id.Value, ev);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)

--- a/src/Apollo.Database/ToDos/ToDoStore.cs
+++ b/src/Apollo.Database/ToDos/ToDoStore.cs
@@ -1,5 +1,4 @@
 using Apollo.Core;
-using Apollo.Core.Dashboard;
 using Apollo.Core.ToDos;
 using Apollo.Database.ToDos.Events;
 using Apollo.Domain.People.ValueObjects;
@@ -12,7 +11,7 @@ using Marten;
 
 namespace Apollo.Database.ToDos;
 
-public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvider, IDashboardUpdatePublisher dashboardUpdatePublisher) : IToDoStore
+public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvider) : IToDoStore
 {
   public async Task<Result> CompleteAsync(ToDoId id, CancellationToken cancellationToken = default)
   {
@@ -22,8 +21,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(id.Value, new ToDoCompletedEvent(id.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -41,8 +38,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
 
       _ = session.Events.StartStream<DbToDo>(id.Value, [ev]);
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       var newToDo = await session.Events.AggregateStreamAsync<DbToDo>(id.Value, token: cancellationToken);
 
       return newToDo is null ? Result.Fail<ToDo>("Failed to create new toDo") : Result.Ok((ToDo)newToDo);
@@ -61,8 +56,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(id.Value, new ToDoDeletedEvent(id.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -115,8 +108,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(id.Value, new ToDoUpdatedEvent(id.Value, description.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -133,8 +124,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(toDoId.Value, new ToDoPriorityUpdatedEvent(toDoId.Value, (int)priority.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -151,8 +140,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(toDoId.Value, new ToDoEnergyUpdatedEvent(toDoId.Value, (int)energy.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)
@@ -169,8 +156,6 @@ public sealed class ToDoStore(IDocumentSession session, TimeProvider timeProvide
       _ = session.Events.Append(toDoId.Value, new ToDoInterestUpdatedEvent(toDoId.Value, (int)interest.Value, time));
 
       await session.SaveChangesAsync(cancellationToken);
-      await dashboardUpdatePublisher.PublishOverviewUpdatedAsync(cancellationToken);
-
       return Result.Ok();
     }
     catch (Exception ex)

--- a/src/Apollo.GRPC/Service/ApolloGrpcService.cs
+++ b/src/Apollo.GRPC/Service/ApolloGrpcService.cs
@@ -254,7 +254,7 @@ public sealed class ApolloGrpcService(
     }
 
     // Grant access to the target user
-    var grantResult = await personStore.GrantAccessAsync(personResult.Value.Id);
+    var grantResult = await mediator.Send(new GrantPersonAccessCommand(personResult.Value.Id));
 
     return grantResult.IsFailed
       ? (GrpcResult<string>)grantResult.Errors.Select(e => new GrpcError(e.Message)).ToArray()
@@ -280,7 +280,7 @@ public sealed class ApolloGrpcService(
     }
 
     // Revoke access from the target user
-    var revokeResult = await personStore.RevokeAccessAsync(personResult.Value.Id);
+    var revokeResult = await mediator.Send(new RevokePersonAccessCommand(personResult.Value.Id));
 
     return revokeResult.IsFailed
       ? (GrpcResult<string>)revokeResult.Errors.Select(e => new GrpcError(e.Message)).ToArray()

--- a/src/Apollo.Service/Jobs/ToDoReminderJob.cs
+++ b/src/Apollo.Service/Jobs/ToDoReminderJob.cs
@@ -1,3 +1,4 @@
+using Apollo.Application.Reminders;
 using Apollo.Core;
 using Apollo.Core.Logging;
 using Apollo.Core.Notifications;
@@ -5,6 +6,8 @@ using Apollo.Core.People;
 using Apollo.Core.ToDos;
 using Apollo.Domain.ToDos.Models;
 using Apollo.Domain.ToDos.ValueObjects;
+
+using MediatR;
 
 using Quartz;
 
@@ -16,6 +19,7 @@ public class ToDoReminderJob(
   IPersonStore personStore,
   IPersonNotificationClient notificationClient,
   IReminderMessageGenerator reminderMessageGenerator,
+  IMediator mediator,
   ILogger<ToDoReminderJob> logger) : IJob
 {
   public async Task Execute(IJobExecutionContext context)
@@ -99,7 +103,7 @@ public class ToDoReminderJob(
 
           foreach (var reminder in personReminders)
           {
-            var markAsSentResult = await reminderStore.MarkAsSentAsync(reminder.Id, context.CancellationToken);
+            var markAsSentResult = await mediator.Send(new MarkReminderSentCommand(reminder.Id), context.CancellationToken);
             if (markAsSentResult.IsFailed)
             {
               ToDoLogs.LogFailedToMarkReminderAsSent(logger, reminder.Id.Value, markAsSentResult.GetErrorMessages());

--- a/src/Client/src/services/dashboardApi.ts
+++ b/src/Client/src/services/dashboardApi.ts
@@ -53,6 +53,25 @@ export interface DashboardOverview {
 
 const FETCH_TIMEOUT_MS = 10_000
 
+async function extractErrorDetail(response: Response): Promise<string> {
+  try {
+    const contentType = response.headers.get('content-type') ?? ''
+
+    if (contentType.includes('application/json')) {
+      const body = await response.json() as unknown
+      if (body && typeof body === 'object' && 'error' in body) {
+        const detail = (body as { error?: unknown }).error
+        return typeof detail === 'string' ? detail : JSON.stringify(detail)
+      }
+      return JSON.stringify(body)
+    }
+
+    return await response.text()
+  } catch {
+    return ''
+  }
+}
+
 export async function getDashboardOverview(): Promise<DashboardOverview> {
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
@@ -71,34 +90,9 @@ export async function getDashboardOverview(): Promise<DashboardOverview> {
   }
 
   if (!response.ok) {
-    let errorMessage = `Failed to fetch dashboard overview: ${response.status} ${response.statusText}`
-
-    try {
-      const contentType = response.headers.get('content-type') ?? ''
-
-      if (contentType.includes('application/json')) {
-        const body = await response.json()
-        if (body && typeof body === 'object' && 'error' in body) {
-          const errorDetail = (body as { error?: unknown }).error
-          if (typeof errorDetail === 'string') {
-            errorMessage += ` - ${errorDetail}`
-          } else if (errorDetail !== undefined) {
-            errorMessage += ` - ${JSON.stringify(errorDetail)}`
-          }
-        } else if (body !== undefined) {
-          errorMessage += ` - ${JSON.stringify(body)}`
-        }
-      } else {
-        const text = await response.text()
-        if (text) {
-          errorMessage += ` - ${text}`
-        }
-      }
-    } catch {
-      // Ignore parsing problems and preserve the original HTTP error.
-    }
-
-    throw new Error(errorMessage)
+    const detail = await extractErrorDetail(response)
+    const suffix = detail ? ` - ${detail}` : ''
+    throw new Error(`Failed to fetch dashboard overview: ${response.status} ${response.statusText}${suffix}`)
   }
 
   return await response.json() as DashboardOverview

--- a/tests/Apollo.Application.Tests/Config/SaveConfigurationCommandTests.cs
+++ b/tests/Apollo.Application.Tests/Config/SaveConfigurationCommandTests.cs
@@ -3,6 +3,8 @@ using Apollo.Core.Configuration;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.Config;
@@ -17,6 +19,7 @@ public sealed class SaveConfigurationCommandTests
   public async Task HandleSavesConfigurationSuccessfullyAsync()
   {
     var store = new Mock<IConfigurationStore>();
+    var mediator = new Mock<IMediator>();
     var expectedConfig = new ConfigurationData
     {
       Id = Guid.NewGuid(),
@@ -27,7 +30,7 @@ public sealed class SaveConfigurationCommandTests
     _ = store.Setup(x => x.UpdateAiAsync("gpt-4", "https://api.openai.com", "secret", It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(expectedConfig));
 
-    var handler = new UpdateAiConfigurationCommandHandler(store.Object);
+    var handler = new UpdateAiConfigurationCommandHandler(store.Object, mediator.Object);
     var result = await handler.Handle(
       new UpdateAiConfigurationCommand("gpt-4", "https://api.openai.com", "secret"),
       CancellationToken.None);
@@ -44,6 +47,7 @@ public sealed class SaveConfigurationCommandTests
   public async Task HandleDesignatesSuperAdminDuringInitialSetupAsync()
   {
     var store = new Mock<IConfigurationStore>();
+    var mediator = new Mock<IMediator>();
     var expectedConfig = new ConfigurationData
     {
       Id = Guid.NewGuid(),
@@ -52,7 +56,7 @@ public sealed class SaveConfigurationCommandTests
     _ = store.Setup(x => x.UpdateSuperAdminAsync("discord-user-123", It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(expectedConfig));
 
-    var handler = new UpdateSuperAdminConfigurationCommandHandler(store.Object);
+    var handler = new UpdateSuperAdminConfigurationCommandHandler(store.Object, mediator.Object);
     var result = await handler.Handle(
       new UpdateSuperAdminConfigurationCommand("discord-user-123"),
       CancellationToken.None);
@@ -69,10 +73,11 @@ public sealed class SaveConfigurationCommandTests
   public async Task HandleReturnsFailureWhenStoreFailsAsync()
   {
     var store = new Mock<IConfigurationStore>();
+    var mediator = new Mock<IMediator>();
     _ = store.Setup(x => x.UpdateAiAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Fail<ConfigurationData>("Database connection failed"));
 
-    var handler = new UpdateAiConfigurationCommandHandler(store.Object);
+    var handler = new UpdateAiConfigurationCommandHandler(store.Object, mediator.Object);
     var result = await handler.Handle(
       new UpdateAiConfigurationCommand("gpt-4", "https://api.openai.com", null),
       CancellationToken.None);

--- a/tests/Apollo.Application.Tests/Conversations/ProcessIncomingMessageCommandHandlerTests.cs
+++ b/tests/Apollo.Application.Tests/Conversations/ProcessIncomingMessageCommandHandlerTests.cs
@@ -80,7 +80,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     // Assert
     Assert.True(result.IsSuccess);
     Assert.Equal("Hello back", result.Value.Content.Value);
-    _mockConversationStore.Verify(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()), Times.Once);
+    _mockConversationStore.Verify(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   [Fact]
@@ -112,7 +112,10 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(Result.Fail<Conversation>("Not found"));
+
+    _ = _mockConversationStore.Setup(x => x.CreateAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Fail<Conversation>("Database error"));
 
     // Act
@@ -135,7 +138,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(conversation));
 
     _ = _mockConversationStore.Setup(x => x.AddMessageAsync(conversationId, It.IsAny<Content>(), It.IsAny<CancellationToken>()))
@@ -172,7 +175,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(conversation));
 
     _ = _mockConversationStore.Setup(x => x.AddMessageAsync(conversation.Id, It.IsAny<Content>(), It.IsAny<CancellationToken>()))

--- a/tests/Apollo.Application.Tests/Conversations/ProcessIncomingMessageCommandHandlerTests.cs
+++ b/tests/Apollo.Application.Tests/Conversations/ProcessIncomingMessageCommandHandlerTests.cs
@@ -80,7 +80,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     // Assert
     Assert.True(result.IsSuccess);
     Assert.Equal("Hello back", result.Value.Content.Value);
-    _mockConversationStore.Verify(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()), Times.Once);
+    _mockConversationStore.Verify(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()), Times.Once);
   }
 
   [Fact]
@@ -112,10 +112,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
-        .ReturnsAsync(Result.Fail<Conversation>("Not found"));
-
-    _ = _mockConversationStore.Setup(x => x.CreateAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Fail<Conversation>("Database error"));
 
     // Act
@@ -138,7 +135,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
         .ReturnsAsync(Result.Ok(conversation));
 
     _ = _mockConversationStore.Setup(x => x.AddMessageAsync(conversationId, It.IsAny<Content>(), It.IsAny<CancellationToken>()))
@@ -175,7 +172,7 @@ public class ProcessIncomingMessageCommandHandlerTests
     _ = _mockPersonStore.Setup(x => x.GetAsync(personId, It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(CreatePerson(personId)));
 
-    _ = _mockConversationStore.Setup(x => x.GetConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
+    _ = _mockConversationStore.Setup(x => x.GetOrCreateConversationByPersonIdAsync(personId, It.IsAny<CancellationToken>()))
       .ReturnsAsync(Result.Ok(conversation));
 
     _ = _mockConversationStore.Setup(x => x.AddMessageAsync(conversation.Id, It.IsAny<Content>(), It.IsAny<CancellationToken>()))

--- a/tests/Apollo.Application.Tests/ToDos/AddReminderCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/AddReminderCommandTests.cs
@@ -7,6 +7,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.ToDos;
@@ -19,7 +21,8 @@ public class AddReminderCommandHandlerTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var reminderDate = DateTime.UtcNow.AddMinutes(30);
@@ -57,7 +60,8 @@ public class AddReminderCommandHandlerTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var reminderDate = DateTime.UtcNow.AddMinutes(30);
@@ -79,7 +83,8 @@ public class AddReminderCommandHandlerTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new AddReminderCommandHandler(toDoStore.Object, reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var reminderDate = DateTime.UtcNow.AddMinutes(30);

--- a/tests/Apollo.Application.Tests/ToDos/CompleteToDoCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/CompleteToDoCommandTests.cs
@@ -6,6 +6,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -20,8 +22,9 @@ public class CompleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<CompleteToDoCommandHandler>>();
-    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
 
@@ -41,8 +44,9 @@ public class CompleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<CompleteToDoCommandHandler>>();
-    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var quartzJobId = new QuartzJobId(Guid.NewGuid());
@@ -84,8 +88,9 @@ public class CompleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<CompleteToDoCommandHandler>>();
-    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new CompleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var otherToDoId = new ToDoId(Guid.NewGuid());

--- a/tests/Apollo.Application.Tests/ToDos/CreateReminderCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/CreateReminderCommandTests.cs
@@ -7,6 +7,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.ToDos;
@@ -18,7 +20,8 @@ public class CreateReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var personId = new PersonId(Guid.NewGuid());
     const string details = "Get coffee";
@@ -48,7 +51,8 @@ public class CreateReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var personId = new PersonId(Guid.NewGuid());
     const string details = "Get coffee";
@@ -69,7 +73,8 @@ public class CreateReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new CreateReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var personId = new PersonId(Guid.NewGuid());
     const string details = "Get coffee";

--- a/tests/Apollo.Application.Tests/ToDos/CreateToDoCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/CreateToDoCommandTests.cs
@@ -6,6 +6,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.ToDos;
@@ -18,7 +20,8 @@ public class CreateToDoCommandTests
     var store = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new CreateToDoCommandHandler(store.Object, reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new CreateToDoCommandHandler(store.Object, reminderStore.Object, scheduler.Object, mediator.Object);
 
     var personId = new PersonId(Guid.NewGuid());
     var description = new Description("test");
@@ -75,7 +78,8 @@ public class CreateToDoCommandTests
     var store = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new CreateToDoCommandHandler(store.Object, reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new CreateToDoCommandHandler(store.Object, reminderStore.Object, scheduler.Object, mediator.Object);
 
     var personId = new PersonId(Guid.NewGuid());
     var description = new Description("test");

--- a/tests/Apollo.Application.Tests/ToDos/DeleteToDoCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/DeleteToDoCommandTests.cs
@@ -6,6 +6,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -20,9 +22,10 @@ public class DeleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<DeleteToDoCommandHandler>>();
     _ = logger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(true);
-    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var quartzJobId = new QuartzJobId(Guid.NewGuid());
@@ -71,9 +74,10 @@ public class DeleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<DeleteToDoCommandHandler>>();
     _ = logger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(true);
-    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var quartzJobId = new QuartzJobId(Guid.NewGuid());
@@ -122,9 +126,10 @@ public class DeleteToDoCommandTests
     var toDoStore = new Mock<IToDoStore>();
     var reminderStore = new Mock<IReminderStore>();
     var toDoReminderScheduler = new Mock<IToDoReminderScheduler>();
+    var mediator = new Mock<IMediator>();
     var logger = new Mock<ILogger<DeleteToDoCommandHandler>>();
     _ = logger.Setup(x => x.IsEnabled(LogLevel.Warning)).Returns(true);
-    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, logger.Object);
+    var handler = new DeleteToDoCommandHandler(toDoStore.Object, reminderStore.Object, toDoReminderScheduler.Object, mediator.Object, logger.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var quartzJobId = new QuartzJobId(Guid.NewGuid());

--- a/tests/Apollo.Application.Tests/ToDos/ReminderCleanupCommandBehaviorTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/ReminderCleanupCommandBehaviorTests.cs
@@ -6,6 +6,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Microsoft.Extensions.Logging;
 
 using Moq;
@@ -164,10 +166,11 @@ public sealed class ReminderCleanupCommandBehaviorTests
     public Mock<IToDoStore> ToDoStore { get; } = new();
     public Mock<IReminderStore> ReminderStore { get; } = new();
     public Mock<IToDoReminderScheduler> Scheduler { get; } = new();
+    public Mock<IMediator> Mediator { get; } = new();
     public Mock<ILogger<DeleteToDoCommandHandler>> DeleteLogger { get; } = new();
     public Mock<ILogger<CompleteToDoCommandHandler>> CompleteLogger { get; } = new();
 
-    public DeleteToDoCommandHandler DeleteHandler => new(ToDoStore.Object, ReminderStore.Object, Scheduler.Object, DeleteLogger.Object);
-    public CompleteToDoCommandHandler CompleteHandler => new(ToDoStore.Object, ReminderStore.Object, Scheduler.Object, CompleteLogger.Object);
+    public DeleteToDoCommandHandler DeleteHandler => new(ToDoStore.Object, ReminderStore.Object, Scheduler.Object, Mediator.Object, DeleteLogger.Object);
+    public CompleteToDoCommandHandler CompleteHandler => new(ToDoStore.Object, ReminderStore.Object, Scheduler.Object, Mediator.Object, CompleteLogger.Object);
   }
 }

--- a/tests/Apollo.Application.Tests/ToDos/RemoveReminderCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/RemoveReminderCommandTests.cs
@@ -6,6 +6,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.ToDos;
@@ -17,7 +19,8 @@ public class RemoveReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var reminderId = new ReminderId(Guid.NewGuid());
@@ -57,7 +60,8 @@ public class RemoveReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var otherToDoId = new ToDoId(Guid.NewGuid());
@@ -90,7 +94,8 @@ public class RemoveReminderCommandHandlerTests
   {
     var reminderStore = new Mock<IReminderStore>();
     var scheduler = new Mock<IToDoReminderScheduler>();
-    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new RemoveReminderCommandHandler(reminderStore.Object, scheduler.Object, mediator.Object);
 
     var toDoId = new ToDoId(Guid.NewGuid());
     var reminderId = new ReminderId(Guid.NewGuid());

--- a/tests/Apollo.Application.Tests/ToDos/UpdateToDoCommandTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/UpdateToDoCommandTests.cs
@@ -4,6 +4,8 @@ using Apollo.Domain.ToDos.ValueObjects;
 
 using FluentResults;
 
+using MediatR;
+
 using Moq;
 
 namespace Apollo.Application.Tests.ToDos;
@@ -15,7 +17,8 @@ public class UpdateToDoCommandTests
   {
     // Arrange
     var toDoStore = new Mock<IToDoStore>();
-    var handler = new UpdateToDoCommandHandler(toDoStore.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new UpdateToDoCommandHandler(toDoStore.Object, mediator.Object);
     var toDoId = new ToDoId(Guid.NewGuid());
     var description = new Description("Updated description");
 
@@ -36,7 +39,8 @@ public class UpdateToDoCommandTests
   {
     // Arrange
     var toDoStore = new Mock<IToDoStore>();
-    var handler = new UpdateToDoCommandHandler(toDoStore.Object);
+    var mediator = new Mock<IMediator>();
+    var handler = new UpdateToDoCommandHandler(toDoStore.Object, mediator.Object);
     var toDoId = new ToDoId(Guid.NewGuid());
     var description = new Description("Updated description");
 

--- a/tests/Apollo.Database.Tests/Config/AppConfigStoreTests.cs
+++ b/tests/Apollo.Database.Tests/Config/AppConfigStoreTests.cs
@@ -1,5 +1,4 @@
 using Apollo.Database.Configuration;
-using Apollo.Core.Dashboard;
 
 using Marten;
 using Marten.Events;
@@ -11,12 +10,10 @@ namespace Apollo.Database.Tests.Config;
 public sealed class AppConfigStoreTests
 {
   private readonly Mock<IDocumentSession> _sessionMock;
-  private readonly Mock<IDashboardUpdatePublisher> _dashboardUpdatePublisherMock;
 
   public AppConfigStoreTests()
   {
     _sessionMock = new Mock<IDocumentSession>(MockBehavior.Loose);
-    _dashboardUpdatePublisherMock = new Mock<IDashboardUpdatePublisher>(MockBehavior.Loose);
   }
 
   /// <summary>
@@ -31,7 +28,7 @@ public sealed class AppConfigStoreTests
       .Setup(s => s.LoadAsync<DbConfiguration>(ConfigurationId.Root, It.IsAny<CancellationToken>()))
       .ReturnsAsync((DbConfiguration?)null);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
 
     // Act
     var result = await store.GetAsync();
@@ -61,7 +58,7 @@ public sealed class AppConfigStoreTests
       .Setup(e => e.AggregateStreamAsync(ConfigurationId.Root, It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(new DbConfiguration { Id = ConfigurationId.Root });
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
     _ = await store.UpdateAiAsync("model", "https://endpoint", "key");
 
     eventStoreMock.As<IEventOperations>().Verify(
@@ -92,7 +89,7 @@ public sealed class AppConfigStoreTests
       .Setup(e => e.AggregateStreamAsync(ConfigurationId.Root, It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(new DbConfiguration { Id = ConfigurationId.Root, AiModelId = "new-model" });
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
     _ = await store.UpdateAiAsync("new-model", "https://endpoint", "key");
 
     eventStoreMock.As<IEventOperations>().Verify(
@@ -101,33 +98,6 @@ public sealed class AppConfigStoreTests
     eventStoreMock.As<IEventOperations>().Verify(
       e => e.StartStream<DbConfiguration>(ConfigurationId.Root, It.IsAny<object[]>()),
       Times.Never);
-  }
-
-  /// <summary>
-  /// Mutating configuration operations should notify the dashboard publisher.
-  /// </summary>
-  [Fact]
-  public async Task UpdateAiAsyncPublishesDashboardUpdateAsync()
-  {
-    _ = _sessionMock
-      .Setup(s => s.LoadAsync<DbConfiguration>(ConfigurationId.Root, It.IsAny<CancellationToken>()))
-      .ReturnsAsync(new DbConfiguration { Id = ConfigurationId.Root });
-    _ = _sessionMock
-      .Setup(s => s.SaveChangesAsync(It.IsAny<CancellationToken>()))
-      .Returns(Task.CompletedTask);
-
-    var eventStoreMock = new Mock<IEventStoreOperations>(MockBehavior.Loose);
-    _ = _sessionMock.SetupGet(s => s.Events).Returns(eventStoreMock.Object);
-    _ = eventStoreMock
-      .Setup(e => e.AggregateStreamAsync(ConfigurationId.Root, It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<DbConfiguration?>()))
-      .ReturnsAsync(new DbConfiguration { Id = ConfigurationId.Root });
-
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
-    _ = await store.UpdateAiAsync("model", "https://endpoint", "key");
-
-    _dashboardUpdatePublisherMock.Verify(
-      p => p.PublishOverviewUpdatedAsync(It.IsAny<CancellationToken>()),
-      Times.Once);
   }
 
   /// <summary>
@@ -161,15 +131,12 @@ public sealed class AppConfigStoreTests
       .Setup(e => e.AggregateStreamAsync(ConfigurationId.Root, It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(updatedConfig);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
     var result = await store.UpdateDiscordAsync(token, publicKey, botName);
 
     Assert.True(result.IsSuccess);
     Assert.Equal(token, result.Value.DiscordToken);
     Assert.Equal(botName, result.Value.DiscordBotName);
-    _dashboardUpdatePublisherMock.Verify(
-      p => p.PublishOverviewUpdatedAsync(It.IsAny<CancellationToken>()),
-      Times.Once);
   }
 
   /// <summary>
@@ -199,14 +166,11 @@ public sealed class AppConfigStoreTests
       .Setup(e => e.AggregateStreamAsync(ConfigurationId.Root, It.IsAny<long>(), It.IsAny<DateTimeOffset?>(), It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(updatedConfig);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
     var result = await store.UpdateSuperAdminAsync(discordUserId);
 
     Assert.True(result.IsSuccess);
     Assert.Equal(discordUserId, result.Value.SuperAdminDiscordUserId);
-    _dashboardUpdatePublisherMock.Verify(
-      p => p.PublishOverviewUpdatedAsync(It.IsAny<CancellationToken>()),
-      Times.Once);
   }
 
   /// <summary>
@@ -251,7 +215,7 @@ public sealed class AppConfigStoreTests
         It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(updatedConfig);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
 
     // Act
     var result = await store.UpdateAiAsync(modelId, endpoint, apiKey);
@@ -310,7 +274,7 @@ public sealed class AppConfigStoreTests
         It.IsAny<DbConfiguration?>()))
       .ReturnsAsync(updatedConfig);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
 
     // Act
     var result = await store.UpdateAiAsync(modelId, endpoint, apiKey);
@@ -321,11 +285,10 @@ public sealed class AppConfigStoreTests
   }
 
   /// <summary>
-  /// When SaveChangesAsync throws, the store should return a failure result and must NOT
-  /// call PublishOverviewUpdatedAsync (the DB write did not succeed).
+  /// When SaveChangesAsync throws, the store should return a failure result.
   /// </summary>
   [Fact]
-  public async Task UpdateAiAsyncDoesNotPublishWhenSaveChangesFailsAsync()
+  public async Task UpdateAiAsyncReturnsFailWhenSaveChangesThrowsAsync()
   {
     _ = _sessionMock
       .Setup(s => s.LoadAsync<DbConfiguration>(ConfigurationId.Root, It.IsAny<CancellationToken>()))
@@ -337,13 +300,10 @@ public sealed class AppConfigStoreTests
     var eventStoreMock = new Mock<IEventStoreOperations>(MockBehavior.Loose);
     _ = _sessionMock.SetupGet(s => s.Events).Returns(eventStoreMock.Object);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
     var result = await store.UpdateAiAsync("model", "https://endpoint", "key");
 
     Assert.True(result.IsFailed);
-    _dashboardUpdatePublisherMock.Verify(
-      p => p.PublishOverviewUpdatedAsync(It.IsAny<CancellationToken>()),
-      Times.Never);
   }
 
   /// <summary>
@@ -358,7 +318,7 @@ public sealed class AppConfigStoreTests
       .Setup(s => s.LoadAsync<DbConfiguration>(ConfigurationId.Root, It.IsAny<CancellationToken>()))
       .ReturnsAsync((DbConfiguration?)null);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
 
     // Act
     var result = await store.IsInitializedAsync();
@@ -382,7 +342,7 @@ public sealed class AppConfigStoreTests
       .Setup(s => s.LoadAsync<DbConfiguration>(ConfigurationId.Root, It.IsAny<CancellationToken>()))
       .ReturnsAsync(existingConfig);
 
-    var store = new ConfigurationStore(_sessionMock.Object, _dashboardUpdatePublisherMock.Object);
+    var store = new ConfigurationStore(_sessionMock.Object);
 
     // Act
     var result = await store.IsInitializedAsync();


### PR DESCRIPTION
## Summary

- **Caddy reverse proxy**: adds Caddy as the sole public entrypoint (HTTP :8083, HTTPS :8443 by default); all app services (`apollo-api`, `apollo-discord`, `apollo-service`) moved from `ports` to `expose` so they're internal-only. Set `CADDY_HOST`, `CADDY_HTTP_PORT`, `CADDY_HTTPS_PORT` in `.env` for production (`apollothecat.app`, 80, 443).
- **MIME type fix**: SPA catch-all in `Program.cs` now also excludes `/assets/*`, so `UseStaticFiles()` correctly serves JS/CSS with proper content types instead of returning `index.html`.
- **Error handling standardisation**: replaced all raw `Errors.Count > 0 ? Errors[0].Message : "Unknown error"` patterns with the existing `GetErrorMessages()` extension across `ProcessIncomingMessageCommand`, `DashboardOverviewService`, `SetupController`, `ToDoPlugin`, and `PersonPlugin`.
- **`dashboardApi.ts` refactor**: extracted `extractErrorDetail` helper to flatten the nested error-body parsing logic.
- **DI validation**: removed the `ValidateOnBuild = false` suppression from `Apollo.API` — the targeted MediatR assembly scan made it unnecessary.
- **`DashboardConnectionTracker`**: switched bare field reads to `Volatile.Read` to ensure cross-thread visibility consistent with the `Interlocked` writes.
- **MediatR notification refactor**: replaced `IDashboardUpdatePublisher` in all database stores with fine-grained MediatR notifications.