### PR TITLE
fix: honor user timezones in fuzzy parsing

### DIFF
--- a/src/Apollo.Application/ToDos/FuzzyTimeParser.cs
+++ b/src/Apollo.Application/ToDos/FuzzyTimeParser.cs
@@ -39,7 +39,7 @@ public sealed class FuzzyTimeParser : IFuzzyTimeParser
 
     foreach (var parser in Parsers)
     {
-      var reference = parser is Parsers.DurationParser ? utcReference : localReference;
+      var reference = parser is IUsesUtcReferenceTimeExpressionParser ? utcReference : localReference;
       var result = parser.TryParse(input, reference);
       if (result.IsSuccess)
       {

--- a/src/Apollo.Application/ToDos/FuzzyTimeParser.cs
+++ b/src/Apollo.Application/ToDos/FuzzyTimeParser.cs
@@ -24,19 +24,22 @@ public sealed class FuzzyTimeParser : IFuzzyTimeParser
 {
   private static readonly IReadOnlyList<ITimeExpressionParser> Parsers = DiscoverParsers();
 
-  public Result<DateTime> TryParseFuzzyTime(string input, DateTime referenceTimeUtc)
+  public Result<DateTime> TryParseFuzzyTime(string input, DateTime referenceTimeUtc, string? userTimeZoneId = null)
   {
     if (string.IsNullOrWhiteSpace(input))
     {
       return Result.Fail<DateTime>("Input is empty or whitespace");
     }
 
-    var reference = referenceTimeUtc.Kind == DateTimeKind.Utc
+    var utcReference = referenceTimeUtc.Kind == DateTimeKind.Utc
       ? referenceTimeUtc
       : DateTime.SpecifyKind(referenceTimeUtc, DateTimeKind.Utc);
 
+    var localReference = GetLocalReferenceTime(utcReference, userTimeZoneId);
+
     foreach (var parser in Parsers)
     {
+      var reference = parser is Parsers.DurationParser ? utcReference : localReference;
       var result = parser.TryParse(input, reference);
       if (result.IsSuccess)
       {
@@ -59,5 +62,28 @@ public sealed class FuzzyTimeParser : IFuzzyTimeParser
         && parserType.IsAssignableFrom(t)
         && t.IsDefined(attributeType, inherit: false))
       .Select(t => (ITimeExpressionParser)Activator.CreateInstance(t)!)];
+  }
+
+  private static DateTime GetLocalReferenceTime(DateTime utcReference, string? userTimeZoneId)
+  {
+    if (string.IsNullOrWhiteSpace(userTimeZoneId))
+    {
+      return utcReference;
+    }
+
+    try
+    {
+      var timeZone = TimeZoneInfo.FindSystemTimeZoneById(userTimeZoneId);
+      var localReference = TimeZoneInfo.ConvertTimeFromUtc(utcReference, timeZone);
+      return DateTime.SpecifyKind(localReference, DateTimeKind.Unspecified);
+    }
+    catch (TimeZoneNotFoundException)
+    {
+      return utcReference;
+    }
+    catch (InvalidTimeZoneException)
+    {
+      return utcReference;
+    }
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/ClockTimeParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/ClockTimeParser.cs
@@ -42,11 +42,11 @@ public sealed partial class ClockTimeParser : ITimeExpressionParser
 
     return timeStr switch
     {
-      "noon" => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.AddHours(12))),
-      "midnight" => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.AddDays(1))),
+      "noon" => Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(reference.Date.AddHours(12))),
+      "midnight" => Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(reference.Date.AddDays(1))),
       _ => TimeParserHelpers.ParseTimeOfDay(timeStr) switch
       {
-        { IsSuccess: true } timeResult => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.Add(timeResult.Value))),
+        { IsSuccess: true } timeResult => Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(reference.Date.Add(timeResult.Value))),
         _ => Result.Fail<DateTime>($"Could not resolve clock time '{timeStr}'")
       }
     };

--- a/src/Apollo.Application/ToDos/Parsers/ClockTimeParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/ClockTimeParser.cs
@@ -42,11 +42,11 @@ public sealed partial class ClockTimeParser : ITimeExpressionParser
 
     return timeStr switch
     {
-      "noon" => Result.Ok(TimeParserHelpers.EnsureUtc(reference.Date.AddHours(12))),
-      "midnight" => Result.Ok(TimeParserHelpers.EnsureUtc(reference.Date.AddDays(1))),
+      "noon" => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.AddHours(12))),
+      "midnight" => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.AddDays(1))),
       _ => TimeParserHelpers.ParseTimeOfDay(timeStr) switch
       {
-        { IsSuccess: true } timeResult => Result.Ok(TimeParserHelpers.EnsureUtc(reference.Date.Add(timeResult.Value))),
+        { IsSuccess: true } timeResult => Result.Ok(TimeParserHelpers.PreserveInputKind(reference.Date.Add(timeResult.Value))),
         _ => Result.Fail<DateTime>($"Could not resolve clock time '{timeStr}'")
       }
     };

--- a/src/Apollo.Application/ToDos/Parsers/DayOfWeekParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/DayOfWeekParser.cs
@@ -56,6 +56,6 @@ public sealed partial class DayOfWeekParser : ITimeExpressionParser
       }
     }
 
-    return Result.Ok(TimeParserHelpers.EnsureUtc(date));
+    return Result.Ok(TimeParserHelpers.PreserveInputKind(date));
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/DayOfWeekParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/DayOfWeekParser.cs
@@ -31,7 +31,7 @@ public sealed partial class DayOfWeekParser : ITimeExpressionParser
   {
     if (NextWeekPattern().IsMatch(input))
     {
-      return Result.Ok(TimeParserHelpers.EnsureUtc(referenceTimeUtc.AddDays(7)));
+      return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(referenceTimeUtc.AddDays(7)));
     }
 
     var dayMatch = DayPattern().Match(input);
@@ -56,6 +56,6 @@ public sealed partial class DayOfWeekParser : ITimeExpressionParser
       }
     }
 
-    return Result.Ok(TimeParserHelpers.PreserveInputKind(date));
+    return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(date));
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/DurationParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/DurationParser.cs
@@ -13,7 +13,7 @@ namespace Apollo.Application.ToDos.Parsers;
 ///           "5 minutes", "2 hours".
 /// </summary>
 [TimeExpressionParser]
-public sealed partial class DurationParser : ITimeExpressionParser
+public sealed partial class DurationParser : ITimeExpressionParser, IUsesUtcReferenceTimeExpressionParser
 {
   // "in N unit" — minutes, hours, days, weeks with common abbreviations
   [GeneratedRegex(

--- a/src/Apollo.Application/ToDos/Parsers/EndOfPeriodParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/EndOfPeriodParser.cs
@@ -23,7 +23,7 @@ public sealed partial class EndOfPeriodParser : ITimeExpressionParser
   {
     if (EndOfDayPattern().IsMatch(input))
     {
-      return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(17)));
+      return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(referenceTimeUtc.Date.AddHours(17)));
     }
 
     if (EndOfWeekPattern().IsMatch(input))
@@ -34,7 +34,7 @@ public sealed partial class EndOfPeriodParser : ITimeExpressionParser
         daysUntilFriday = 7;
       }
       var endOfWeek = referenceTimeUtc.Date.AddDays(daysUntilFriday).AddHours(17);
-      return Result.Ok(TimeParserHelpers.PreserveInputKind(endOfWeek));
+      return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(endOfWeek));
     }
 
     return Result.Fail<DateTime>($"'{input}' is not an end-of-period expression");

--- a/src/Apollo.Application/ToDos/Parsers/EndOfPeriodParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/EndOfPeriodParser.cs
@@ -23,7 +23,7 @@ public sealed partial class EndOfPeriodParser : ITimeExpressionParser
   {
     if (EndOfDayPattern().IsMatch(input))
     {
-      return Result.Ok(TimeParserHelpers.EnsureUtc(referenceTimeUtc.Date.AddHours(17)));
+      return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(17)));
     }
 
     if (EndOfWeekPattern().IsMatch(input))
@@ -34,7 +34,7 @@ public sealed partial class EndOfPeriodParser : ITimeExpressionParser
         daysUntilFriday = 7;
       }
       var endOfWeek = referenceTimeUtc.Date.AddDays(daysUntilFriday).AddHours(17);
-      return Result.Ok(TimeParserHelpers.EnsureUtc(endOfWeek));
+      return Result.Ok(TimeParserHelpers.PreserveInputKind(endOfWeek));
     }
 
     return Result.Fail<DateTime>($"'{input}' is not an end-of-period expression");

--- a/src/Apollo.Application/ToDos/Parsers/TimeOfDayAliasParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TimeOfDayAliasParser.cs
@@ -27,7 +27,7 @@ public sealed partial class TimeOfDayAliasParser : ITimeExpressionParser
 
     if (match.Groups["tonight"].Success)
     {
-      return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(20)));
+      return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(referenceTimeUtc.Date.AddHours(20)));
     }
 
     var hours = match.Groups["period"].Value.ToLowerInvariant() switch
@@ -38,6 +38,6 @@ public sealed partial class TimeOfDayAliasParser : ITimeExpressionParser
       _ => 12
     };
 
-    return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(hours)));
+    return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(referenceTimeUtc.Date.AddHours(hours)));
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/TimeOfDayAliasParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TimeOfDayAliasParser.cs
@@ -27,7 +27,7 @@ public sealed partial class TimeOfDayAliasParser : ITimeExpressionParser
 
     if (match.Groups["tonight"].Success)
     {
-      return Result.Ok(TimeParserHelpers.EnsureUtc(referenceTimeUtc.Date.AddHours(20)));
+      return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(20)));
     }
 
     var hours = match.Groups["period"].Value.ToLowerInvariant() switch
@@ -38,6 +38,6 @@ public sealed partial class TimeOfDayAliasParser : ITimeExpressionParser
       _ => 12
     };
 
-    return Result.Ok(TimeParserHelpers.EnsureUtc(referenceTimeUtc.Date.AddHours(hours)));
+    return Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.Date.AddHours(hours)));
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/TimeParserHelpers.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TimeParserHelpers.cs
@@ -70,7 +70,7 @@ internal static class TimeParserHelpers
     };
   }
 
-  internal static DateTime PreserveInputKind(DateTime dt)
+  internal static DateTime KeepUtcElseUseUnspecified(DateTime dt)
   {
     return dt.Kind == DateTimeKind.Utc
       ? dt

--- a/src/Apollo.Application/ToDos/Parsers/TimeParserHelpers.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TimeParserHelpers.cs
@@ -69,4 +69,11 @@ internal static class TimeParserHelpers
       _ => dt
     };
   }
+
+  internal static DateTime PreserveInputKind(DateTime dt)
+  {
+    return dt.Kind == DateTimeKind.Utc
+      ? dt
+      : DateTime.SpecifyKind(dt, DateTimeKind.Unspecified);
+  }
 }

--- a/src/Apollo.Application/ToDos/Parsers/TomorrowParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TomorrowParser.cs
@@ -35,7 +35,7 @@ public sealed partial class TomorrowParser : ITimeExpressionParser
       if (timeResult.IsSuccess)
       {
         var dt = referenceTimeUtc.Date.AddDays(1).Add(timeResult.Value);
-        return Result.Ok(TimeParserHelpers.EnsureUtc(dt));
+        return Result.Ok(TimeParserHelpers.PreserveInputKind(dt));
       }
     }
 
@@ -50,11 +50,11 @@ public sealed partial class TomorrowParser : ITimeExpressionParser
         _ => 9
       };
       var dt = referenceTimeUtc.Date.AddDays(1).AddHours(hours);
-      return Result.Ok(TimeParserHelpers.EnsureUtc(dt));
+      return Result.Ok(TimeParserHelpers.PreserveInputKind(dt));
     }
 
     return TomorrowPattern().IsMatch(input)
-      ? Result.Ok(TimeParserHelpers.EnsureUtc(referenceTimeUtc.AddDays(1)))
+      ? Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.AddDays(1)))
       : Result.Fail<DateTime>($"'{input}' is not a tomorrow expression");
   }
 }

--- a/src/Apollo.Application/ToDos/Parsers/TomorrowParser.cs
+++ b/src/Apollo.Application/ToDos/Parsers/TomorrowParser.cs
@@ -35,7 +35,7 @@ public sealed partial class TomorrowParser : ITimeExpressionParser
       if (timeResult.IsSuccess)
       {
         var dt = referenceTimeUtc.Date.AddDays(1).Add(timeResult.Value);
-        return Result.Ok(TimeParserHelpers.PreserveInputKind(dt));
+        return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(dt));
       }
     }
 
@@ -50,11 +50,11 @@ public sealed partial class TomorrowParser : ITimeExpressionParser
         _ => 9
       };
       var dt = referenceTimeUtc.Date.AddDays(1).AddHours(hours);
-      return Result.Ok(TimeParserHelpers.PreserveInputKind(dt));
+      return Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(dt));
     }
 
     return TomorrowPattern().IsMatch(input)
-      ? Result.Ok(TimeParserHelpers.PreserveInputKind(referenceTimeUtc.AddDays(1)))
+      ? Result.Ok(TimeParserHelpers.KeepUtcElseUseUnspecified(referenceTimeUtc.AddDays(1)))
       : Result.Fail<DateTime>($"'{input}' is not a tomorrow expression");
   }
 }

--- a/src/Apollo.Application/ToDos/TimeParsingService.cs
+++ b/src/Apollo.Application/ToDos/TimeParsingService.cs
@@ -174,5 +174,9 @@ public sealed class TimeParsingService(
     {
       return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
     }
+    catch (ArgumentException)
+    {
+      return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
+    }
   }
 }

--- a/src/Apollo.Application/ToDos/TimeParsingService.cs
+++ b/src/Apollo.Application/ToDos/TimeParsingService.cs
@@ -51,7 +51,7 @@ public sealed class TimeParsingService(
     var now = timeProvider.GetUtcNow().UtcDateTime;
 
     // Step 1: Try FuzzyTimeParser (natural language patterns)
-    var fuzzyResult = fuzzyTimeParser.TryParseFuzzyTime(input, now);
+    var fuzzyResult = fuzzyTimeParser.TryParseFuzzyTime(input, now, userTimeZoneId);
     if (fuzzyResult.IsSuccess)
     {
       var utcFuzzy = ConvertToUtc(fuzzyResult.Value, userTimeZoneId);

--- a/src/Apollo.Core/ToDos/IFuzzyTimeParser.cs
+++ b/src/Apollo.Core/ToDos/IFuzzyTimeParser.cs
@@ -11,7 +11,8 @@ public interface IFuzzyTimeParser
   /// Attempts to parse a fuzzy time expression.
   /// </summary>
   /// <param name="input">The input string to parse (e.g., "in 10 minutes", "tomorrow")</param>
-  /// <param name="referenceTimeUtc">The reference time to calculate relative times from (should be UTC)</param>
-  /// <returns>A Result containing the parsed UTC DateTime if successful, or failure if the input is not a recognized fuzzy time format</returns>
-  Result<DateTime> TryParseFuzzyTime(string input, DateTime referenceTimeUtc);
+  /// <param name="referenceTimeUtc">The UTC reference time used for relative duration expressions.</param>
+  /// <param name="userTimeZoneId">The user's timezone used to interpret wall-clock expressions like "tomorrow at 3pm".</param>
+  /// <returns>A Result containing the parsed DateTime if successful, or failure if the input is not a recognized fuzzy time format.</returns>
+  Result<DateTime> TryParseFuzzyTime(string input, DateTime referenceTimeUtc, string? userTimeZoneId = null);
 }

--- a/src/Apollo.Core/ToDos/IUsesUtcReferenceTimeExpressionParser.cs
+++ b/src/Apollo.Core/ToDos/IUsesUtcReferenceTimeExpressionParser.cs
@@ -1,0 +1,6 @@
+namespace Apollo.Core.ToDos;
+
+/// <summary>
+/// Marks fuzzy time parsers that should evaluate relative expressions against a UTC reference.
+/// </summary>
+public interface IUsesUtcReferenceTimeExpressionParser;

--- a/tests/Apollo.Application.Tests/ToDos/FuzzyTimeParserTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/FuzzyTimeParserTests.cs
@@ -83,4 +83,15 @@ public class FuzzyTimeParserTests
     Assert.True(result.IsSuccess);
     Assert.Equal(new DateTime(2025, 12, 30, 1, 40, 0, DateTimeKind.Utc), result.Value);
   }
+
+  [Fact]
+  public void TryParseFuzzyTimeWithTimezoneKeepsLocalReferenceForNextWeek()
+  {
+    var utcReference = new DateTime(2025, 12, 30, 1, 30, 0, DateTimeKind.Utc);
+
+    var result = _parser.TryParseFuzzyTime("next week", utcReference, "America/Chicago");
+
+    Assert.True(result.IsSuccess);
+    Assert.Equal(new DateTime(2026, 1, 5, 19, 30, 0, DateTimeKind.Unspecified), result.Value);
+  }
 }

--- a/tests/Apollo.Application.Tests/ToDos/FuzzyTimeParserTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/FuzzyTimeParserTests.cs
@@ -63,13 +63,24 @@ public class FuzzyTimeParserTests
   }
 
   [Fact]
-  public void TryParseFuzzyTimeConvertsUnspecifiedKindToUtc()
+  public void TryParseFuzzyTimeWithTimezoneUsesLocalReferenceForWallClockExpressions()
   {
-    var unspecifiedReference = new DateTime(2025, 12, 30, 12, 0, 0, DateTimeKind.Unspecified);
+    var utcReference = new DateTime(2025, 12, 30, 1, 30, 0, DateTimeKind.Utc);
 
-    var result = _parser.TryParseFuzzyTime("in 10 minutes", unspecifiedReference);
+    var result = _parser.TryParseFuzzyTime("tomorrow at 3pm", utcReference, "America/Chicago");
 
     Assert.True(result.IsSuccess);
-    Assert.Equal(DateTimeKind.Utc, result.Value.Kind);
+    Assert.Equal(new DateTime(2025, 12, 30, 15, 0, 0, DateTimeKind.Unspecified), result.Value);
+  }
+
+  [Fact]
+  public void TryParseFuzzyTimeWithTimezoneKeepsUtcReferenceForDurations()
+  {
+    var utcReference = new DateTime(2025, 12, 30, 1, 30, 0, DateTimeKind.Utc);
+
+    var result = _parser.TryParseFuzzyTime("in 10 minutes", utcReference, "America/Chicago");
+
+    Assert.True(result.IsSuccess);
+    Assert.Equal(new DateTime(2025, 12, 30, 1, 40, 0, DateTimeKind.Utc), result.Value);
   }
 }

--- a/tests/Apollo.Application.Tests/ToDos/TimeParsingServiceTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/TimeParsingServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class TimeParsingServiceTests
     // Arrange
     var expected = ReferenceTime.AddMinutes(10);
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime, null))
       .Returns(Result.Ok(expected));
 
     // Act
@@ -39,7 +39,7 @@ public sealed class TimeParsingServiceTests
     // Assert
     Assert.True(result.IsSuccess);
     Assert.Equal(expected, result.Value);
-    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime), Times.Once);
+    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime, null), Times.Once);
   }
 
   [Theory]
@@ -50,7 +50,7 @@ public sealed class TimeParsingServiceTests
   {
     // Arrange - fuzzy parser fails
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -69,7 +69,7 @@ public sealed class TimeParsingServiceTests
   {
     // Arrange - fuzzy parser fails
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -93,7 +93,7 @@ public sealed class TimeParsingServiceTests
   {
     // Arrange - fuzzy parser fails
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, timezone))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -116,7 +116,7 @@ public sealed class TimeParsingServiceTests
   {
     // Arrange - fuzzy parser fails
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -135,7 +135,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy parser fails, C# parsing fails, LLM returns UNPARSEABLE
     const string input = "not a time at all";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     var mockBuilder = new Mock<IAIRequestBuilder>();
@@ -158,7 +158,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy parser fails, falls through to C# parsing
     const string input = "2025-12-31T10:00:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, "America/Chicago"))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act - America/Chicago is UTC-6
@@ -176,7 +176,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy parser fails
     const string input = "2025-12-31T10:00:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act - no timezone specified
@@ -194,7 +194,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy parser fails, a date without explicit kind
     const string input = "Dec 31, 2025";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, "America/New_York"))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act - with timezone
@@ -217,7 +217,7 @@ public sealed class TimeParsingServiceTests
 
     // Assert
     Assert.True(result.IsFailed);
-    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime(It.IsAny<string>(), It.IsAny<DateTime>()), Times.Never);
+    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string?>()), Times.Never);
   }
 
   [Fact]
@@ -226,7 +226,7 @@ public sealed class TimeParsingServiceTests
     // Arrange
     var expected = ReferenceTime.AddHours(1);
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime("in an hour", ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime("in an hour", ReferenceTime, null))
       .Returns(Result.Ok(expected));
 
     // Act
@@ -235,7 +235,7 @@ public sealed class TimeParsingServiceTests
     // Assert
     Assert.True(result.IsSuccess);
     Assert.Equal(expected, result.Value);
-    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime("in an hour", ReferenceTime), Times.Once);
+    _fuzzyTimeParser.Verify(p => p.TryParseFuzzyTime("in an hour", ReferenceTime, null), Times.Once);
     _aiAgent.Verify(a => a.CreateTimeParsingRequestAsync(It.IsAny<string>(), It.IsAny<string>(),
       It.IsAny<string>()), Times.Never);
   }
@@ -246,7 +246,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy parser fails, but C# parsing succeeds
     const string input = "2025-12-31T10:00:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -264,7 +264,7 @@ public sealed class TimeParsingServiceTests
     // Arrange - fuzzy and C# parsers fail, LLM succeeds
     const string input = "day after tomorrow at 5pm";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     var mockBuilder = new Mock<IAIRequestBuilder>();
@@ -287,7 +287,7 @@ public sealed class TimeParsingServiceTests
     // Arrange
     const string input = "buy groceries";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     var mockBuilder = new Mock<IAIRequestBuilder>();
@@ -310,7 +310,7 @@ public sealed class TimeParsingServiceTests
     // Arrange
     const string input = "some weird expression";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     var mockBuilder = new Mock<IAIRequestBuilder>();
@@ -333,7 +333,7 @@ public sealed class TimeParsingServiceTests
     // Arrange
     const string input = "something complex";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     var mockBuilder = new Mock<IAIRequestBuilder>();
@@ -357,7 +357,7 @@ public sealed class TimeParsingServiceTests
     // "tomorrow at 3pm" → fuzzy returns 2025-12-31T15:00:00 with Unspecified kind
     var fuzzyParsed = new DateTime(2025, 12, 31, 15, 0, 0, DateTimeKind.Unspecified);
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime("tomorrow at 3pm", ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime("tomorrow at 3pm", ReferenceTime, "America/Chicago"))
       .Returns(Result.Ok(fuzzyParsed));
 
     // Act — America/Chicago is UTC-6 in winter
@@ -369,12 +369,28 @@ public sealed class TimeParsingServiceTests
   }
 
   [Fact]
+  public async Task ParseTimeAsyncWithFuzzyTomorrowUsesUserTimezoneForDayBoundaryAsync()
+  {
+    var boundaryReference = new DateTime(2025, 12, 30, 1, 30, 0, DateTimeKind.Utc);
+    var boundaryTimeProvider = new Mock<TimeProvider>();
+    _ = boundaryTimeProvider.Setup(tp => tp.GetUtcNow()).Returns(new DateTimeOffset(boundaryReference));
+
+    var parser = new FuzzyTimeParser();
+    var service = new TimeParsingService(parser, _aiAgent.Object, boundaryTimeProvider.Object);
+
+    var result = await service.ParseTimeAsync("tomorrow at 3pm", "America/Chicago");
+
+    Assert.True(result.IsSuccess);
+    Assert.Equal(new DateTime(2025, 12, 30, 21, 0, 0, DateTimeKind.Utc), result.Value);
+  }
+
+  [Fact]
   public async Task ParseTimeAsyncWithFuzzyTimeAndNoTimezoneReturnsUtcDirectlyAsync()
   {
     // Arrange — fuzzy parser returns UTC time (relative durations)
     var expected = new DateTime(2025, 12, 30, 14, 40, 0, DateTimeKind.Utc);
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime("in 10 minutes", ReferenceTime, null))
       .Returns(Result.Ok(expected));
 
     // Act — no timezone provided
@@ -391,7 +407,7 @@ public sealed class TimeParsingServiceTests
     // Arrange — fuzzy parser fails
     const string input = "2025-12-31T10:00:00Z";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -408,7 +424,7 @@ public sealed class TimeParsingServiceTests
     // Arrange — fuzzy parser fails
     const string input = "2025-12-31T10:00:00-05:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, null))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act
@@ -425,7 +441,7 @@ public sealed class TimeParsingServiceTests
     // Arrange — fuzzy parser fails, C# parsing succeeds with Unspecified kind
     const string input = "2025-12-31T10:00:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, "Invalid/Timezone"))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act — invalid timezone should not throw, should fallback to UTC
@@ -442,7 +458,7 @@ public sealed class TimeParsingServiceTests
     // Arrange — fuzzy parser fails, C# parsing succeeds
     const string input = "2025-12-31T10:00:00";
     _ = _fuzzyTimeParser
-      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime))
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, "   "))
       .Returns(Result.Fail<DateTime>("Not fuzzy"));
 
     // Act — empty string timezone should behave like null

--- a/tests/Apollo.Application.Tests/ToDos/TimeParsingServiceTests.cs
+++ b/tests/Apollo.Application.Tests/ToDos/TimeParsingServiceTests.cs
@@ -468,4 +468,18 @@ public sealed class TimeParsingServiceTests
     Assert.True(result.IsSuccess);
     Assert.Equal(new DateTime(2025, 12, 31, 10, 0, 0, DateTimeKind.Utc), result.Value);
   }
+
+  [Fact]
+  public async Task ParseTimeAsyncWithInvalidLocalTimeFallsBackToUtcAsync()
+  {
+    const string input = "2025-03-09T02:30:00";
+    _ = _fuzzyTimeParser
+      .Setup(p => p.TryParseFuzzyTime(input, ReferenceTime, "America/Chicago"))
+      .Returns(Result.Fail<DateTime>("Not fuzzy"));
+
+    var result = await _service.ParseTimeAsync(input, "America/Chicago");
+
+    Assert.True(result.IsSuccess);
+    Assert.Equal(new DateTime(2025, 3, 9, 2, 30, 0, DateTimeKind.Utc), result.Value);
+  }
 }


### PR DESCRIPTION
## Summary
- use the user's timezone when resolving fuzzy wall-clock expressions so inputs like `tomorrow at 3pm` respect local day boundaries
- keep relative duration parsing anchored to UTC while returning wall-clock fuzzy results as user-local values for final UTC conversion
- add coverage for timezone-aware fuzzy parsing and the day-boundary regression behind #193

Closes #193